### PR TITLE
Document NoETL business OS and terminal workspace

### DIFF
--- a/docs/ai-meta/agent-orchestration.md
+++ b/docs/ai-meta/agent-orchestration.md
@@ -1,12 +1,46 @@
 ---
 sidebar_position: 7
 title: Agent Orchestration with NoETL
-description: Using NoETL as a registry and orchestrator for AI agents
+description: Using NoETL as a distributed business operating system for agentic playbooks
 ---
 
 # Agent Orchestration with NoETL
 
-NoETL can serve as both a **registry** and **orchestrator** for AI agents, where each agent is defined as a NoETL playbook. This page explains why the mapping is natural, what it looks like in practice, and what needs to be built.
+NoETL can serve as both a **registry** and **orchestrator** for AI agents, where each agent is defined as a NoETL playbook. More broadly, NoETL is evolving toward a distributed business operating system: a shell, catalog, scheduler, execution fabric, event log, and observability plane for business tasks described in the NoETL DSL.
+
+The analogy is intentional. A distributed operating system presents many networked nodes as one coherent system. NoETL applies the same idea to business execution: many playbooks, workers, credentials, AI tools, APIs, and Kubernetes resources appear to users as one programmable workspace for running work.
+
+---
+
+## NoETL as a Distributed Business Operating System
+
+In NoETL, the "process" is a playbook execution. The "program" is a DSL playbook. The "shell" is the CLI, GUI prompt, API, or scheduler that launches work. The "kernel services" are catalog registration, dispatch, credentials, event sourcing, execution projections, and worker coordination.
+
+| Distributed OS Concept | NoETL Business OS Equivalent |
+|---|---|
+| Single system image | One catalog and prompt surface across server, workers, schedules, and APIs |
+| Process management | Playbook execution, status, cancellation, rerun, and supervision |
+| Inter-process communication | NATS subjects, nested playbooks, event streams, and result references |
+| Resource management | Kubernetes workers, credentials, external systems, storage, and AI models |
+| Transparency | Users run `noetl` tasks without manually choosing every worker or service |
+| Reliability | Event sourcing in `noetl.event`, command projection in `noetl.command`, and execution projection in `noetl.execution` |
+| Scheduling | Cron, event-driven triggers, external API calls, and user prompt commands |
+| Observability | Execution dashboard, event detail, diagnostics, reports, and AI-assisted analysis |
+
+NoETL does not replace Kubernetes. Kubernetes is the substrate for container scheduling and cluster operations. NoETL sits above it as the domain operating layer for business work: discovering tasks, binding credentials, invoking tools, coordinating AI agents, and explaining what happened.
+
+### The NoETL Prompt
+
+The NoETL prompt is the interactive shell for that workspace:
+
+```text
+noetl@kind:/execution$ run fixtures/playbooks/hello_world
+noetl@kind:/execution$ executions failed
+noetl@kind:/execution$ report 612955956145554347
+noetl@kind:/execution$ fix 612955956145554347
+```
+
+The prompt should always show the active context, such as local kind, a server API, or a gateway-backed environment. Over time it becomes the primary operating interface for users and agents to run playbooks, inspect status, retrieve reports, schedule work, and repair failed executions.
 
 ---
 

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -5,13 +5,26 @@ description: NoETL GUI prompt commands for catalog discovery, execution, diagnos
 
 # Terminal Console
 
-The NoETL GUI includes a terminal-style console at the top of the authenticated app. The prompt shows the active runtime context and current view:
+The NoETL GUI uses a terminal-style console as the primary navigation surface at the top of the authenticated app. The prompt shows the active runtime context and current view:
 
 ```text
 noetl@kind:/execution$
 ```
 
 The context name tells the user which NoETL server or local API is currently in use. In local development, `kind` usually means the GUI is talking directly to the NoETL API running in the local kind cluster.
+
+The console replaces the traditional horizontal menu, but the regular dashboard/page views remain available in the lower view window. Users can navigate through commands, clickable console results, or route-specific page actions.
+
+## Windows
+
+The UI is split into two terminal-like windows:
+
+| Window | Purpose |
+|---|---|
+| Console window | Navigation, commands, execution launch, reports, and diagnostics. |
+| View window | The regular GUI page for catalog, editor, execution observability, credentials, travel, or users. |
+
+Both windows can be hidden and shown. Hiding the console leaves the current view open; hiding the view leaves the console available as a command-only workspace.
 
 ## Command Reference
 
@@ -46,6 +59,8 @@ Console output can include clickable actions. For example:
 - `executions` returns actions to open or report on recent executions.
 
 These actions keep the terminal-like workflow fast while preserving the regular GUI navigation and full page views.
+
+Console output rows can also be closed. Longer outputs expose compact/expanded controls so users can keep only the useful command history visible.
 
 ## Navigation Examples
 

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -35,7 +35,7 @@ Both windows can be hidden and shown. Hiding the console leaves the current view
 | `menu` | Show clickable GUI navigation targets. |
 | `ls` | List the current workspace options, including views and contextual commands. |
 | `cd <view>` | Navigate to a view such as `catalog`, `editor`, `execution`, `credentials`, `travel`, or `users`. |
-| `open <view\|execution_id>` | Open a view or execution detail page. |
+| `open <view&#124;execution_id>` | Open a view or execution detail page. |
 | `status` | Call the NoETL health endpoint and print the current server status. |
 | `playbooks [query]` | List registered playbooks, optionally filtered by path, name, or description. |
 | `catalog [query]` | Alias for `playbooks`. |

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -1,0 +1,63 @@
+---
+title: Terminal Console
+description: NoETL GUI prompt commands for catalog discovery, execution, diagnostics, and reports
+---
+
+# Terminal Console
+
+The NoETL GUI includes a terminal-style console at the top of the authenticated app. The prompt shows the active runtime context and current view:
+
+```text
+noetl@kind:/execution$
+```
+
+The context name tells the user which NoETL server or local API is currently in use. In local development, `kind` usually means the GUI is talking directly to the NoETL API running in the local kind cluster.
+
+## Command Reference
+
+| Command | Description |
+|---|---|
+| `help` | Show the supported console commands. |
+| `context` | Show the active NoETL runtime mode, API base URL, and skip-auth setting. |
+| `status` | Call the NoETL health endpoint and print the current server status. |
+| `playbooks [query]` | List registered playbooks, optionally filtered by path, name, or description. |
+| `catalog [query]` | Alias for `playbooks`. |
+| `executions [status]` | List recent executions, optionally filtered by status such as `completed`, `failed`, `running`, or `pending`. |
+| `ps [status]` | Alias for `executions`. |
+| `run <playbook> [payload]` | Start a playbook by catalog ID or path. Payload can be JSON or `--set key=value` pairs. |
+| `report <execution_id>` | Load execution detail, print status, result, and event count, then open the execution detail page. |
+| `fix <execution_id>` | Run the execution diagnostic API and print the analysis bundle. |
+| `diagnose <execution_id>` | Alias for `fix`. |
+| `rerun <execution_id> [payload]` | Rerun a previous execution, optionally with replacement workload. |
+| `stop <execution_id>` | Request cancellation/stop for a running execution. |
+| `clear` | Clear the console history. |
+
+## Payloads
+
+For `run` and `rerun`, the console accepts JSON:
+
+```text
+noetl@kind:/execution$ run fixtures/playbooks/hello_world {"name":"NoETL"}
+```
+
+It also accepts shell-style values:
+
+```text
+noetl@kind:/execution$ run fixtures/playbooks/hello_world --set name=NoETL --set limit=10
+```
+
+Values that parse as finite numbers are sent as numbers; other values are sent as strings.
+
+## Operating Model
+
+The console is the first GUI shell for NoETL as a distributed business operating system:
+
+- The catalog is the program registry.
+- A playbook execution is a process.
+- `noetl.event` is the event-sourcing log.
+- `noetl.command` is the worker command projection.
+- `noetl.execution` is the execution-state projection.
+- Kubernetes supplies the distributed runtime substrate.
+- The console, CLI, API, and scheduler are user and agent entrypoints into the same workspace.
+
+Keep this page updated whenever console commands or command semantics change.

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -19,6 +19,10 @@ The context name tells the user which NoETL server or local API is currently in 
 |---|---|
 | `help` | Show the supported console commands. |
 | `context` | Show the active NoETL runtime mode, API base URL, and skip-auth setting. |
+| `menu` | Show clickable GUI navigation targets. |
+| `ls` | List the current workspace options, including views and contextual commands. |
+| `cd <view>` | Navigate to a view such as `catalog`, `editor`, `execution`, `credentials`, `travel`, or `users`. |
+| `open <view\|execution_id>` | Open a view or execution detail page. |
 | `status` | Call the NoETL health endpoint and print the current server status. |
 | `playbooks [query]` | List registered playbooks, optionally filtered by path, name, or description. |
 | `catalog [query]` | Alias for `playbooks`. |
@@ -31,6 +35,26 @@ The context name tells the user which NoETL server or local API is currently in 
 | `rerun <execution_id> [payload]` | Rerun a previous execution, optionally with replacement workload. |
 | `stop <execution_id>` | Request cancellation/stop for a running execution. |
 | `clear` | Clear the console history. |
+
+## Clickable Results
+
+Console output can include clickable actions. For example:
+
+- `menu` returns clickable view targets.
+- `ls` returns view targets plus useful contextual commands.
+- `playbooks` returns runnable playbook actions.
+- `executions` returns actions to open or report on recent executions.
+
+These actions keep the terminal-like workflow fast while preserving the regular GUI navigation and full page views.
+
+## Navigation Examples
+
+```text
+noetl@kind:/execution$ menu
+noetl@kind:/execution$ cd editor
+noetl@kind:/editor$ open execution
+noetl@kind:/execution$ open 612955956145554347
+```
 
 ## Payloads
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -201,6 +201,7 @@ const sidebars: SidebarsConfig = {
       label: 'GUI',
       items: [
         'gui',
+        'gui/terminal-console',
         'gui/custom-ui-gateway',
       ],
     },


### PR DESCRIPTION
## Summary
- Frames NoETL as a distributed business operating system.
- Documents the terminal console, prompt navigation, and command surface.
- Adds GUI console/view-window documentation to keep docs aligned with the new workspace model.

## Validation
- Documentation-only change; reviewed generated markdown content.
