### PR TITLE
docs: document MCP agent execution

### DIFF
--- a/docs/ai-meta/agent-orchestration.md
+++ b/docs/ai-meta/agent-orchestration.md
@@ -76,11 +76,11 @@ NoETL's server already handles capabilities 1 through 4 for playbooks. NATS prov
 
 ### How NoETL Covers Each
 
-**Registration:** Every playbook deployed to the server is registered. Adding `metadata.agent: true` and `metadata.capabilities` to agent playbooks makes them discoverable as agents specifically.
+**Registration:** Every playbook deployed to the server is registered. Agent playbooks keep YAML `kind: Playbook` for DSL execution, but can be stored in `noetl.catalog` with catalog kind `agent`. Adding `metadata.agent: true` and `metadata.capabilities` makes them discoverable as agents specifically.
 
-**Discovery:** The server tracks all deployed playbooks. Extending the query API to filter by metadata (e.g., "find agents with capability `code-review`") enables agent discovery.
+**Discovery:** The server tracks versioned resources through `noetl.catalog.kind` and `noetl.resource.name`. Resource kinds include `playbook`, `agent`, `mcp`, `memory`, and `credential`, with capability filters for agent discovery.
 
-**Invocation:** `noetl exec <playbook> --set key=value` already starts a playbook with input parameters. An agent invocation is the same call.
+**Invocation:** `noetl exec <playbook> --set key=value` already starts a playbook with input parameters. An agent invocation is the same call, with `resource_kind: "agent"` when the catalog entry is registered as an agent.
 
 **State tracking:** `noetl status` shows running, completed, and failed executions. Agent status is playbook execution status.
 
@@ -252,7 +252,9 @@ The agents do not need to know about each other. The parent playbook handles seq
 | Playbook execution engine | Yes | No change needed |
 | Agent metadata in playbooks | Yes | Implemented via `metadata.agent` and `metadata.capabilities` extraction on catalog registration |
 | Discovery by capability | Yes | Implemented via `/catalog/list` filters and `/catalog/agents/list` endpoint |
+| Catalog resource kinds | Yes | `noetl.resource` defines `playbook`, `agent`, `mcp`, `memory`, and `credential`; `playbook` and `agent` are executable |
 | ADK/LangChain bridge tool | Yes (initial) | Implemented as `tool.kind: agent` with `framework: adk|langchain|custom`, entrypoint loading, and runtime invocation |
+| MCP bridge tool | Yes (initial) | Implemented as `tool.kind: mcp` so agent playbooks can call MCP servers while retaining execution/event traceability |
 | Agent memory read/write | No | Steps that read/write to ai-meta `memory/` or NATS KV store |
 | Inter-agent messaging | Partially (NATS exists) | Standardize a message schema for agent-to-agent results |
 | Agent status in dashboard | Partially (`noetl status`) | Extend to show agent-specific metadata and capabilities |
@@ -273,6 +275,32 @@ NoETL now has a first-class agent runtime bridge. Instead of writing raw Python 
 ```
 
 For ADK-style runners, pass keyword payload fields such as `user_id`, `session_id`, and `new_message`; the runtime bridge maps payload keys to the callable signature and materializes async generator event streams into step output.
+
+### MCP Servers as Agent Tools
+
+MCP servers should be reached through playbook execution rather than direct GUI calls. In this pattern, the playbook is the agent and `kind: mcp` is one of its tools:
+
+```yaml
+metadata:
+  name: kubernetes_runtime_agent
+  path: automation/agents/kubernetes/runtime
+  agent: true
+  capabilities:
+    - kubernetes-observability
+    - mcp:kubernetes
+
+workflow:
+  - step: call_mcp
+    tool:
+      kind: mcp
+      server: kubernetes
+      endpoint: "{{ workload.endpoint }}"
+      method: "{{ workload.method }}"
+      tool: "{{ workload.tool }}"
+      arguments: "{{ workload.arguments }}"
+```
+
+The GUI terminal can translate `k8s pods noetl` into a normal `/execute` request for this playbook with `resource_kind: "agent"`. The Kubernetes MCP server is then called by the worker, and every activity is tracked as NoETL execution state: `noetl.event` is the event log, `noetl.command` is the worker command projection, and `noetl.execution` is the execution-state projection.
 
 ---
 

--- a/docs/ai-meta/agent-orchestration.md
+++ b/docs/ai-meta/agent-orchestration.md
@@ -1,12 +1,46 @@
 ---
 sidebar_position: 7
 title: Agent Orchestration with NoETL
-description: Using NoETL as a registry and orchestrator for AI agents
+description: Using NoETL as a distributed business operating system for agentic playbooks
 ---
 
 # Agent Orchestration with NoETL
 
-NoETL can serve as both a **registry** and **orchestrator** for AI agents, where each agent is defined as a NoETL playbook. This page explains why the mapping is natural, what it looks like in practice, and what needs to be built.
+NoETL can serve as both a **registry** and **orchestrator** for AI agents, where each agent is defined as a NoETL playbook. More broadly, NoETL is evolving toward a distributed business operating system: a shell, catalog, scheduler, execution fabric, event log, and observability plane for business tasks described in the NoETL DSL.
+
+The analogy is intentional. A distributed operating system presents many networked nodes as one coherent system. NoETL applies the same idea to business execution: many playbooks, workers, credentials, AI tools, APIs, and Kubernetes resources appear to users as one programmable workspace for running work.
+
+---
+
+## NoETL as a Distributed Business Operating System
+
+In NoETL, the "process" is a playbook execution. The "program" is a DSL playbook. The "shell" is the CLI, GUI prompt, API, or scheduler that launches work. The "kernel services" are catalog registration, dispatch, credentials, event sourcing, execution projections, and worker coordination.
+
+| Distributed OS Concept | NoETL Business OS Equivalent |
+|---|---|
+| Single system image | One catalog and prompt surface across server, workers, schedules, and APIs |
+| Process management | Playbook execution, status, cancellation, rerun, and supervision |
+| Inter-process communication | NATS subjects, nested playbooks, event streams, and result references |
+| Resource management | Kubernetes workers, credentials, external systems, storage, and AI models |
+| Transparency | Users run `noetl` tasks without manually choosing every worker or service |
+| Reliability | Event sourcing in `noetl.event`, command projection in `noetl.command`, and execution projection in `noetl.execution` |
+| Scheduling | Cron, event-driven triggers, external API calls, and user prompt commands |
+| Observability | Execution dashboard, event detail, diagnostics, reports, and AI-assisted analysis |
+
+NoETL does not replace Kubernetes. Kubernetes is the substrate for container scheduling and cluster operations. NoETL sits above it as the domain operating layer for business work: discovering tasks, binding credentials, invoking tools, coordinating AI agents, and explaining what happened.
+
+### The NoETL Prompt
+
+The NoETL prompt is the interactive shell for that workspace:
+
+```text
+noetl@kind:/execution$ run fixtures/playbooks/hello_world
+noetl@kind:/execution$ executions failed
+noetl@kind:/execution$ report 612955956145554347
+noetl@kind:/execution$ fix 612955956145554347
+```
+
+The prompt should always show the active context, such as local kind, a server API, or a gateway-backed environment. Over time it becomes the primary operating interface for users and agents to run playbooks, inspect status, retrieve reports, schedule work, and repair failed executions.
 
 ---
 

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -472,16 +472,22 @@ noetl register playbook --directory tests/fixtures/playbooks
 
 # Register credentials
 noetl register credential --file credentials/postgres.json
+
+# Register an executable agent playbook
+noetl catalog register automation/agents/kubernetes/runtime.yaml --resource-type agent
 ```
 
 ### Querying Catalog
 
 ```bash
 # List playbooks
-noetl catalog list Playbook
+noetl catalog list playbook
+
+# List agent playbooks
+noetl catalog list agent
 
 # List credentials
-noetl catalog list Credential --json
+noetl catalog list credential --json
 
 # Get specific resource
 noetl catalog get my-playbook

--- a/docs/gateway/index.md
+++ b/docs/gateway/index.md
@@ -6,7 +6,7 @@ description: NoETL Gateway - API gateway for authentication and GraphQL proxy
 
 # NoETL Gateway
 
-The NoETL Gateway is a Rust-based API gateway that provides authentication, authorization, and GraphQL proxy capabilities for the NoETL platform.
+The NoETL Gateway is a Rust-based API gateway that provides authentication, authorization, GraphQL compatibility, and authenticated REST proxy access to the NoETL platform.
 
 :::info Source Code
 For development documentation, local setup, and code details, see the [Gateway Crate README](https://github.com/noetl/noetl/blob/master/crates/gateway/README.md).
@@ -54,9 +54,31 @@ Gateway Request → Check NATS K/V → Cache Hit? → Use cached session (sub-ms
 - **Auth0 Integration**: OAuth2/OIDC authentication via Auth0 Universal Login
 - **Session Caching**: Fast session lookups via NATS K/V cache
 - **Session Management**: Session tokens managed via NoETL playbooks (PostgreSQL source of truth)
-- **GraphQL Proxy**: Authenticated access to NoETL's GraphQL API
+- **GraphQL Compatibility**: Authenticated `executePlaybook` and proxy helpers for clients that prefer GraphQL
+- **REST Proxy**: Canonical `/noetl/*` forwarding to NoETL server `/api/*`
 - **CORS Support**: Configurable cross-origin resource sharing
 - **Stateless Design**: No direct database connections
+
+## Agent and MCP Execution
+
+Gateway does not call MCP servers directly. It authenticates the client and forwards canonical execution requests to NoETL:
+
+```http
+POST /noetl/execute
+{
+  "path": "automation/agents/kubernetes/runtime",
+  "workload": {
+    "method": "tools/call",
+    "tool": "pods_list_in_namespace",
+    "arguments": { "namespace": "noetl" }
+  },
+  "resource_kind": "agent"
+}
+```
+
+The NoETL server dispatches the playbook, the worker executes `kind: mcp`, and the resulting activity is tracked in NoETL execution state. This keeps GUI terminal commands, external API calls, and scheduled jobs on the same agent-as-playbook audit path.
+
+Gateway's typed GraphQL `executePlaybook` mutation also accepts `resourceKind`; use `agent` for catalog entries registered as agent playbooks.
 
 ## API Endpoints
 
@@ -68,6 +90,7 @@ Gateway Request → Check NATS K/V → Cache Hit? → Use cached session (sub-ms
 | `/api/auth/login` | POST | Auth0 token login |
 | `/api/auth/validate` | POST | Validate session |
 | `/api/auth/check-access` | POST | Check playbook permissions |
+| `/api/runtime/contract` | GET | Gateway route and execution contract |
 
 ### Protected Endpoints (Require Authentication)
 

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -5,13 +5,26 @@ description: NoETL GUI prompt commands for catalog discovery, execution, diagnos
 
 # Terminal Console
 
-The NoETL GUI includes a terminal-style console at the top of the authenticated app. The prompt shows the active runtime context and current view:
+The NoETL GUI uses a terminal-style console as the primary navigation surface at the top of the authenticated app. The prompt shows the active runtime context and current view:
 
 ```text
 noetl@kind:/execution$
 ```
 
 The context name tells the user which NoETL server or local API is currently in use. In local development, `kind` usually means the GUI is talking directly to the NoETL API running in the local kind cluster.
+
+The console replaces the traditional horizontal menu, but the regular dashboard/page views remain available in the lower view window. Users can navigate through commands, clickable console results, or route-specific page actions.
+
+## Windows
+
+The UI is split into two terminal-like windows:
+
+| Window | Purpose |
+|---|---|
+| Console window | Navigation, commands, execution launch, reports, and diagnostics. |
+| View window | The regular GUI page for catalog, editor, execution observability, credentials, travel, or users. |
+
+Both windows can be hidden and shown. Hiding the console leaves the current view open; hiding the view leaves the console available as a command-only workspace.
 
 ## Command Reference
 
@@ -46,6 +59,8 @@ Console output can include clickable actions. For example:
 - `executions` returns actions to open or report on recent executions.
 
 These actions keep the terminal-like workflow fast while preserving the regular GUI navigation and full page views.
+
+Console output rows can also be closed. Longer outputs expose compact/expanded controls so users can keep only the useful command history visible.
 
 ## Navigation Examples
 

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -35,7 +35,7 @@ Both windows can be hidden and shown. Hiding the console leaves the current view
 | `menu` | Show clickable GUI navigation targets. |
 | `ls` | List the current workspace options, including views and contextual commands. |
 | `cd <view>` | Navigate to a view such as `catalog`, `editor`, `execution`, `credentials`, `travel`, or `users`. |
-| `open <view\|execution_id>` | Open a view or execution detail page. |
+| `open <view&#124;execution_id>` | Open a view or execution detail page. |
 | `status` | Call the NoETL health endpoint and print the current server status. |
 | `playbooks [query]` | List registered playbooks, optionally filtered by path, name, or description. |
 | `catalog [query]` | Alias for `playbooks`. |

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -47,6 +47,14 @@ Both windows can be hidden and shown. Hiding the console leaves the current view
 | `diagnose <execution_id>` | Alias for `fix`. |
 | `rerun <execution_id> [payload]` | Rerun a previous execution, optionally with replacement workload. |
 | `stop <execution_id>` | Request cancellation/stop for a running execution. |
+| `mcp status` | Launch the Kubernetes runtime agent playbook to inspect MCP availability and tool count. |
+| `mcp tools` | Launch the Kubernetes runtime agent playbook to list exposed MCP tools. |
+| `k8s pods [namespace]` | Launch the Kubernetes runtime agent playbook and list pods. |
+| `k8s namespaces` | Launch the Kubernetes runtime agent playbook and list namespaces. |
+| `k8s events [namespace]` | Launch the Kubernetes runtime agent playbook and list Kubernetes events. |
+| `k8s deployments [namespace]` | Launch the Kubernetes runtime agent playbook and list deployments. |
+| `k8s services [namespace]` | Launch the Kubernetes runtime agent playbook and list services. |
+| `k8s logs <pod> [namespace] [container]` | Launch the Kubernetes runtime agent playbook and fetch recent pod logs. |
 | `clear` | Clear the console history. |
 
 ## Clickable Results
@@ -98,5 +106,33 @@ The console is the first GUI shell for NoETL as a distributed business operating
 - `noetl.execution` is the execution-state projection.
 - Kubernetes supplies the distributed runtime substrate.
 - The console, CLI, API, and scheduler are user and agent entrypoints into the same workspace.
+
+## MCP and Kubernetes Commands
+
+MCP-backed terminal commands are executed through NoETL playbooks, not direct browser-to-MCP calls. The terminal maps Kubernetes commands to the agent playbook `automation/agents/kubernetes/runtime`, then renders the execution ID and final output.
+
+For example, this command:
+
+```text
+noetl@kind:/catalog$ k8s pods mcp
+```
+
+starts a playbook execution equivalent to:
+
+```json
+{
+  "path": "automation/agents/kubernetes/runtime",
+  "workload": {
+    "method": "tools/call",
+    "tool": "pods_list_in_namespace",
+    "arguments": {
+      "namespace": "mcp"
+    }
+  },
+  "resource_kind": "agent"
+}
+```
+
+The resulting MCP request is made by the NoETL worker using `kind: mcp`, so the activity appears in the execution dashboard, event log, command projection, rerun flow, and reports.
 
 Keep this page updated whenever console commands or command semantics change.

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -35,7 +35,7 @@ Both windows can be hidden and shown. Hiding the console leaves the current view
 | `menu` | Show clickable GUI navigation targets. |
 | `ls` | List the current workspace options, including views and contextual commands. |
 | `cd <view>` | Navigate to a view such as `catalog`, `editor`, `execution`, `credentials`, `travel`, or `users`. |
-| `open <view&#124;execution_id>` | Open a view or execution detail page. |
+| `open <view\|execution_id>` | Open a view or execution detail page. |
 | `status` | Call the NoETL health endpoint and print the current server status. |
 | `playbooks [query]` | List registered playbooks, optionally filtered by path, name, or description. |
 | `catalog [query]` | Alias for `playbooks`. |

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -1,0 +1,63 @@
+---
+title: Terminal Console
+description: NoETL GUI prompt commands for catalog discovery, execution, diagnostics, and reports
+---
+
+# Terminal Console
+
+The NoETL GUI includes a terminal-style console at the top of the authenticated app. The prompt shows the active runtime context and current view:
+
+```text
+noetl@kind:/execution$
+```
+
+The context name tells the user which NoETL server or local API is currently in use. In local development, `kind` usually means the GUI is talking directly to the NoETL API running in the local kind cluster.
+
+## Command Reference
+
+| Command | Description |
+|---|---|
+| `help` | Show the supported console commands. |
+| `context` | Show the active NoETL runtime mode, API base URL, and skip-auth setting. |
+| `status` | Call the NoETL health endpoint and print the current server status. |
+| `playbooks [query]` | List registered playbooks, optionally filtered by path, name, or description. |
+| `catalog [query]` | Alias for `playbooks`. |
+| `executions [status]` | List recent executions, optionally filtered by status such as `completed`, `failed`, `running`, or `pending`. |
+| `ps [status]` | Alias for `executions`. |
+| `run <playbook> [payload]` | Start a playbook by catalog ID or path. Payload can be JSON or `--set key=value` pairs. |
+| `report <execution_id>` | Load execution detail, print status, result, and event count, then open the execution detail page. |
+| `fix <execution_id>` | Run the execution diagnostic API and print the analysis bundle. |
+| `diagnose <execution_id>` | Alias for `fix`. |
+| `rerun <execution_id> [payload]` | Rerun a previous execution, optionally with replacement workload. |
+| `stop <execution_id>` | Request cancellation/stop for a running execution. |
+| `clear` | Clear the console history. |
+
+## Payloads
+
+For `run` and `rerun`, the console accepts JSON:
+
+```text
+noetl@kind:/execution$ run fixtures/playbooks/hello_world {"name":"NoETL"}
+```
+
+It also accepts shell-style values:
+
+```text
+noetl@kind:/execution$ run fixtures/playbooks/hello_world --set name=NoETL --set limit=10
+```
+
+Values that parse as finite numbers are sent as numbers; other values are sent as strings.
+
+## Operating Model
+
+The console is the first GUI shell for NoETL as a distributed business operating system:
+
+- The catalog is the program registry.
+- A playbook execution is a process.
+- `noetl.event` is the event-sourcing log.
+- `noetl.command` is the worker command projection.
+- `noetl.execution` is the execution-state projection.
+- Kubernetes supplies the distributed runtime substrate.
+- The console, CLI, API, and scheduler are user and agent entrypoints into the same workspace.
+
+Keep this page updated whenever console commands or command semantics change.

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -19,6 +19,10 @@ The context name tells the user which NoETL server or local API is currently in 
 |---|---|
 | `help` | Show the supported console commands. |
 | `context` | Show the active NoETL runtime mode, API base URL, and skip-auth setting. |
+| `menu` | Show clickable GUI navigation targets. |
+| `ls` | List the current workspace options, including views and contextual commands. |
+| `cd <view>` | Navigate to a view such as `catalog`, `editor`, `execution`, `credentials`, `travel`, or `users`. |
+| `open <view\|execution_id>` | Open a view or execution detail page. |
 | `status` | Call the NoETL health endpoint and print the current server status. |
 | `playbooks [query]` | List registered playbooks, optionally filtered by path, name, or description. |
 | `catalog [query]` | Alias for `playbooks`. |
@@ -31,6 +35,26 @@ The context name tells the user which NoETL server or local API is currently in 
 | `rerun <execution_id> [payload]` | Rerun a previous execution, optionally with replacement workload. |
 | `stop <execution_id>` | Request cancellation/stop for a running execution. |
 | `clear` | Clear the console history. |
+
+## Clickable Results
+
+Console output can include clickable actions. For example:
+
+- `menu` returns clickable view targets.
+- `ls` returns view targets plus useful contextual commands.
+- `playbooks` returns runnable playbook actions.
+- `executions` returns actions to open or report on recent executions.
+
+These actions keep the terminal-like workflow fast while preserving the regular GUI navigation and full page views.
+
+## Navigation Examples
+
+```text
+noetl@kind:/execution$ menu
+noetl@kind:/execution$ cd editor
+noetl@kind:/editor$ open execution
+noetl@kind:/execution$ open 612955956145554347
+```
 
 ## Payloads
 

--- a/docs/reference/catalog-resources.md
+++ b/docs/reference/catalog-resources.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 9
+title: Catalog Resources
+description: Resource kinds stored in the NoETL catalog
+---
+
+# Catalog Resources
+
+NoETL stores registered resources in `noetl.catalog`. The catalog row has a `kind` column that references `noetl.resource.name`, so playbooks, agent playbooks, MCP descriptors, credentials, and memory artifacts can share one versioned registry.
+
+## Resource Kinds
+
+| Kind | Executable | Purpose |
+|---|---:|---|
+| `playbook` | Yes | Standard NoETL workflow definition. |
+| `agent` | Yes | Agent-as-playbook entry that can run operational or AI-assisted work. |
+| `mcp` | No | Model Context Protocol server or tool provider descriptor. |
+| `memory` | No | AI memory, knowledge, or coordination artifact. |
+| `credential` | No | Credential or secret reference metadata. |
+
+The `noetl.resource.meta` field records shared metadata such as `executable` and `catalog`. The execution API only starts executable resources. Supporting resources such as `mcp` and `memory` are used by playbooks and agents so every action still has an execution record.
+
+## Agent Playbooks
+
+Agent playbooks keep the DSL document shape:
+
+```yaml
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: kubernetes_runtime_agent
+  path: automation/agents/kubernetes/runtime
+  agent: true
+```
+
+When registered with `resource_type: "agent"`, the catalog stores the resource as `kind = 'agent'`, while the YAML remains executable as a playbook. This lets the UI and API discover agents separately without creating a second execution model.

--- a/docs/reference/tools/index.md
+++ b/docs/reference/tools/index.md
@@ -30,6 +30,7 @@ See `documentation/docs/reference/dsl/step_spec.md` for the full DSL model.
 | `gcs` | Google Cloud Storage | export/import artifacts |
 | `ducklake` | Lakehouse queries | unified analytics |
 | `nats` | JetStream/KV/Object Store | state, messaging, artifacts |
+| `mcp` | Model Context Protocol calls | agent tools, runtime observability |
 
 ---
 

--- a/docs/reference/tools/mcp.md
+++ b/docs/reference/tools/mcp.md
@@ -1,0 +1,108 @@
+---
+sidebar_position: 11
+title: MCP Tool
+description: Call Model Context Protocol servers from NoETL playbook executions
+---
+
+# MCP Tool
+
+`kind: mcp` lets a NoETL worker call a Model Context Protocol server from inside a playbook execution. This keeps MCP activity in the normal NoETL audit path: the user or scheduler starts a playbook, the server issues a command, the worker calls the MCP server, and the result is recorded in `noetl.event`, `noetl.command`, and the `noetl.execution` projection.
+
+The GUI terminal should use this pattern for operational commands. It should launch an agent playbook and render the resulting execution, rather than calling MCP servers directly from the browser.
+
+## Basic Tool Call
+
+```yaml
+apiVersion: noetl.io/v2
+kind: Playbook
+metadata:
+  name: kubernetes_runtime_agent
+  path: automation/agents/kubernetes/runtime
+  agent: true
+  capabilities:
+    - kubernetes-observability
+    - mcp:kubernetes
+
+workload:
+  endpoint: "http://kubernetes-mcp-server.mcp.svc.cluster.local:8080/mcp"
+  method: tools/call
+  tool: pods_list_in_namespace
+  arguments:
+    namespace: noetl
+
+workflow:
+  - step: call_mcp
+    tool:
+      kind: mcp
+      server: kubernetes
+      endpoint: "{{ workload.endpoint }}"
+      method: "{{ workload.method }}"
+      tool: "{{ workload.tool }}"
+      arguments: "{{ workload.arguments }}"
+```
+
+## Fields
+
+| Field | Description |
+|---|---|
+| `server` | Logical MCP server name. Used for reporting and environment fallback lookup. |
+| `endpoint` | MCP server HTTP endpoint. If omitted, the worker checks `NOETL_MCP_<SERVER>_URL`, then `NOETL_MCP_URL`. |
+| `method` | MCP method. Supported first-class methods are `health`, `tools/list`, and `tools/call`. |
+| `tool` | MCP tool name for `tools/call`. |
+| `arguments` | JSON object passed as MCP tool arguments. |
+| `timeout_seconds` | Request timeout for the MCP operation. Defaults to 60 seconds. |
+
+## Returned Shape
+
+The tool returns an object like:
+
+```json
+{
+  "status": "ok",
+  "server": "kubernetes",
+  "endpoint": "http://kubernetes-mcp-server.mcp.svc.cluster.local:8080/mcp",
+  "method": "tools/call",
+  "tool": "pods_list_in_namespace",
+  "arguments": { "namespace": "noetl" },
+  "text": "NAMESPACE APIVERSION KIND NAME READY STATUS ...",
+  "result": {}
+}
+```
+
+`text` is extracted from MCP text content when present. `result` keeps the raw MCP result object for follow-up steps and reports.
+
+## Operational Model
+
+For runtime observability, prefer a small agent playbook per operational domain:
+
+- `automation/agents/kubernetes/runtime` for Kubernetes read-only operations.
+- Future agent playbooks for databases, queues, storage, or cloud services.
+
+The GUI terminal can map commands such as `k8s pods noetl` to a playbook invocation:
+
+```json
+{
+  "path": "automation/agents/kubernetes/runtime",
+  "workload": {
+    "method": "tools/call",
+    "tool": "pods_list_in_namespace",
+    "arguments": { "namespace": "noetl" }
+  },
+  "resource_kind": "agent"
+}
+```
+
+This makes each terminal action a NoETL execution process with status, events, rerun support, and reports.
+
+## Catalog Registration
+
+Agent playbooks should still use `kind: Playbook` inside YAML so the DSL parser can execute them, but they can be registered in the catalog with resource kind `agent`:
+
+```json
+{
+  "content": "apiVersion: noetl.io/v2\nkind: Playbook\nmetadata:\n  name: kubernetes_runtime_agent\n  path: automation/agents/kubernetes/runtime\n  agent: true\n...",
+  "resource_type": "agent"
+}
+```
+
+The catalog stores that entry as `noetl.catalog.kind = 'agent'`. The execution API treats `playbook` and `agent` as executable resource kinds, while `mcp` and `memory` describe supporting resources that are invoked through agent playbooks.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -201,6 +201,7 @@ const sidebars: SidebarsConfig = {
       label: 'GUI',
       items: [
         'gui',
+        'gui/terminal-console',
         'gui/custom-ui-gateway',
       ],
     },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -98,6 +98,7 @@ const sidebars: SidebarsConfig = {
             'reference/tools/gcs',
             'reference/tools/ducklake',
             'reference/tools/transfer',
+            'reference/tools/mcp',
           ],
         },
         {
@@ -109,6 +110,11 @@ const sidebars: SidebarsConfig = {
           type: 'doc',
           id: 'reference/auth_and_keychain_reference',
           label: 'Authentication & Keychain',
+        },
+        {
+          type: 'doc',
+          id: 'reference/catalog-resources',
+          label: 'Catalog Resources',
         },
         {
           type: 'doc',


### PR DESCRIPTION
## Summary
- document MCP server usage through NoETL agent playbooks rather than direct GUI calls
- add catalog resource-kind reference for `playbook`, `agent`, `mcp`, `memory`, and `credential`
- update GUI terminal, gateway, CLI, and agent-orchestration docs for the new execution model

## Validation
- `npm run build`
- build still reports the existing broken anchor in `reference/recreate-noetl-schema` for `./noetl_cli_usage#database-management`
