### PR TITLE
docs(mcp): end-to-end runbooks (local kind + GKE) + architecture overview

### DIFF
--- a/docs/architecture/mcp_catalog_architecture.md
+++ b/docs/architecture/mcp_catalog_architecture.md
@@ -1,0 +1,329 @@
+---
+id: mcp_catalog_architecture
+title: NoETL Catalog-Driven MCP Architecture
+sidebar_label: MCP Catalog Architecture
+sidebar_position: 2
+---
+
+# NoETL Catalog-Driven MCP Architecture
+
+How NoETL turns the [Model Context Protocol](https://modelcontextprotocol.io/)
+into a first-class object in the catalog: registered alongside
+playbooks and credentials, deployed and operated entirely through
+playbooks, surfaced in the GUI as a friendly form-driven workspace.
+
+This document is a high-level tour. For the deploy walkthrough,
+see [MCP End-to-End on Local Kind](../operations/mcp_end_to_end_local_kind);
+for the GKE variant, see
+[MCP End-to-End on GKE](../operations/mcp_end_to_end_gke).
+
+## Why this design
+
+A working MCP integration needs three things working together:
+
+1. **Where does an MCP server live?** Some are managed services
+   (Anthropic-hosted), some run in-cluster (a kubernetes-mcp-server
+   Deployment), some are local processes. The system has to know
+   how to reach each one *and* how to provision new ones.
+2. **Who can run what?** Granting "may invoke `pods` on the
+   Kubernetes MCP" should not require a separate IAM system —
+   the same authorisation primitives that gate playbook execution
+   should gate MCP tool calls.
+3. **What's it doing right now?** Every MCP call should be
+   visible in the same execution dashboard that shows playbook
+   runs. Same events, same audit trail, same retry semantics.
+
+The answer NoETL converged on: **the catalog is the source of
+truth, and every MCP operation goes through a playbook**.
+
+## The four phases
+
+```mermaid
+flowchart TB
+  subgraph "Phase 1: Catalog"
+    Mcp[(Mcp resource<br/>kind: Mcp)]
+    Playbook[(Lifecycle agents<br/>kind: Playbook)]
+  end
+
+  subgraph "Phase 2: Authorisation"
+    Auth[check_playbook_access<br/>auth.playbook_permissions]
+  end
+
+  subgraph "Phase 3: Lifecycle agents"
+    Deploy[deploy / undeploy / restart]
+    Status[status / discover]
+  end
+
+  subgraph "Phase 4: GUI"
+    Catalog[Catalog browser]
+    RunDialog[Friendly run dialog]
+  end
+
+  Catalog --> Mcp
+  Catalog --> Playbook
+  Mcp -.references.-> Playbook
+  Catalog --> RunDialog
+  RunDialog -- POST /api/mcp/.../lifecycle/{verb} --> Auth
+  Auth -- allowed --> Deploy
+  Auth -- allowed --> Status
+  Deploy -- helm upgrade --> Cluster[(Kubernetes cluster)]
+  Status -- kubectl get --> Cluster
+```
+
+Each phase is implemented and merged:
+
+| Phase | Implementation | Released in |
+|---|---|---|
+| 1 — `Mcp` resource lifecycle endpoint | `/api/mcp/{path}/lifecycle/{verb}` + `_ui_schema` | noetl ≥ 2.26 |
+| 2 — server-side `check_playbook_access` | `noetl/server/api/auth/check_access.py` | noetl ≥ 2.27 |
+| 3 — Kubernetes MCP lifecycle agent fleet | `automation/agents/kubernetes/lifecycle/*` | ops main |
+| 4 — friendly run dialog + Mcp tile renderer | `gui/src/components/PlaybookRunDialog.tsx` | gui ≥ 1.3 |
+
+## Phase 1 — `kind: Mcp` is a catalog resource
+
+`Playbook`, `Credential`, `Memory` and now `Mcp` all live in the
+same catalog table, distinguished by their `kind` column. An
+`Mcp` resource looks like:
+
+```yaml
+apiVersion: noetl.io/v2
+kind: Mcp
+metadata:
+  name: kubernetes
+  path: mcp/kubernetes
+spec:
+  url: http://kubernetes-mcp-server.mcp.svc.cluster.local:8080/mcp
+  protocol: mcp/1.0
+
+  lifecycle:
+    deploy:    automation/agents/kubernetes/lifecycle/deploy
+    undeploy:  automation/agents/kubernetes/lifecycle/undeploy
+    redeploy:  automation/agents/kubernetes/lifecycle/redeploy
+    restart:   automation/agents/kubernetes/lifecycle/restart
+    status:    automation/agents/kubernetes/lifecycle/status
+    discover:  automation/agents/kubernetes/lifecycle/discover
+
+  discovery:
+    initialize_url: http://kubernetes-mcp-server.mcp.svc.cluster.local:8080/healthz
+    tools_list_url: http://kubernetes-mcp-server.mcp.svc.cluster.local:8080/mcp/tools
+    refresh_via:    automation/agents/kubernetes/lifecycle/discover
+
+  runtime:
+    agent: automation/agents/kubernetes/runtime
+
+  deployment:
+    namespace: mcp
+    chart_ref: oci://ghcr.io/containers/charts/kubernetes-mcp-server
+    image_tag: v0.0.61
+    toolsets: "core,config"
+```
+
+Every block describes intent rather than commands:
+
+- `spec.url` — where the running MCP server lives
+- `spec.lifecycle.{verb}` — which playbook deploys/inspects/operates this MCP
+- `spec.runtime.agent` — which playbook the GUI calls when a user invokes a tool
+- `spec.deployment` — knobs the lifecycle agents read at install time
+
+The server exposes:
+
+- `POST /api/mcp/{path}/lifecycle/{verb}` — dispatch a lifecycle agent
+- `POST /api/mcp/{path}/discover` — refresh the tools list
+- `GET /api/catalog/{path}/ui_schema` — render a workload form for any catalog entry
+
+## Phase 2 — auth-as-playbook, server-side
+
+Every dispatch through the MCP routes runs `check_playbook_access`
+*on the server*, against the same `auth.playbook_permissions`
+table the gateway already used:
+
+- `enforce` — deny → 403, missing token → 401, DB error → 503
+- `advisory` — log "would deny", proceed
+- `skip` — pass through (the local-kind default)
+
+The GUI can also call `/api/auth/check-access` itself for UI
+gating (greying out a button before the user clicks it). The
+server-side enforcement is the source of truth even if the GUI
+were lying.
+
+## Phase 3 — lifecycle agents are playbooks
+
+Each lifecycle verb is a regular `kind: Playbook` resource with
+`metadata.agent: true`:
+
+```yaml
+# automation/agents/kubernetes/lifecycle/deploy.yaml
+metadata:
+  name: kubernetes_mcp_lifecycle_deploy
+  path: automation/agents/kubernetes/lifecycle/deploy
+  agent: true
+  capabilities: [kubernetes, mcp:lifecycle:deploy]
+
+workload:
+  mcp_resource: ...   # populated by the dispatcher
+  verb: deploy
+  expected_kube_context: kind-noetl
+
+workflow:
+  - step: deploy
+    tool:
+      kind: shell
+      cmds:
+        - |
+          # in-cluster guard: skip the local-terminal check
+          if [ -z "${KUBERNETES_SERVICE_HOST:-}" ]; then
+            ...
+          fi
+          helm upgrade --install "$RELEASE_NAME" "$CHART_REF" ...
+    next:
+      spec: { mode: exclusive }
+      arcs: [{ step: end }]
+
+  - step: end
+    tool:
+      kind: python
+      code: |
+        result = {"status": "completed", "agent": "...", "text": deploy_output}
+```
+
+A few things worth noticing:
+
+- **Same DSL.** Lifecycle agents use the exact same `workflow:` /
+  `step:` / `tool:` shape every other playbook does. Nothing
+  special about being a "lifecycle agent" beyond the
+  `metadata.agent: true` flag and the `capabilities:` list.
+- **`kind: shell` runs everywhere.** The distributed worker now
+  ships its own shell tool kind that calls `subprocess.run` with
+  Jinja-rendered commands, conservative env forwarding (only
+  PATH + KUBERNETES_SERVICE_HOST + explicit `task.env`), per-cmd
+  timeout, and structured failure aggregation. The local rust
+  binary's `kind: shell` works the same way.
+- **In-cluster vs local.** The `KUBERNETES_SERVICE_HOST` env var
+  (which the kubelet always sets inside a Pod) lets the same
+  agent run from an operator's terminal *or* from a worker pod.
+  The local terminal path keeps the kubectl-context guard;
+  in-cluster execution skips it because the worker's SA already
+  pins it to the right cluster.
+- **Results flow back as events.** The python `end` step
+  explicitly returns a structured result with `status`, `text`,
+  `mcp_path`, `verb`. The dispatcher's `playbook.completed`
+  event surfaces that text inline in the GUI's run dialog.
+
+## Phase 4 — friendly run dialog + Mcp browser
+
+The GUI's catalog browser auto-detects `kind: Mcp` entries and
+renders them as workspaces with verb-buttons:
+
+```
+mcp/kubernetes :: Read-only Kubernetes runtime agent backed by the Kubernetes MCP server
+
+[ status ]  inspect through agent playbook
+[ tools ]   list MCP tools through agent playbook
+[ deploy ]  full helm upgrade via lifecycle.deploy
+[ pods ]    runtime agent: pods across namespaces
+[ events ]  runtime agent: recent cluster events
+...
+```
+
+Each button opens a **friendly run dialog** generated from
+`/api/catalog/{path}/ui_schema`. The endpoint walks the
+playbook's `workload:` block and emits a JSON-Schema-shaped
+description of every field — Antd renders `string` as inputs,
+`enum` as selects, `object` as JSON textareas with live
+validation, `boolean` as checkboxes. The user submits, the
+dispatcher validates the workload against the agent's Pydantic
+contract, and the resulting execution streams back into the
+dialog through SSE.
+
+Two things make this nice in practice:
+
+- **No code path drift.** The form fields are derived from the
+  agent's actual `workload:` schema. If you add a field, the
+  form picks it up next time the user opens the dialog. No
+  `<form>` to maintain alongside the YAML.
+- **Polling is epoch-guarded.** Closing the dialog mid-run can't
+  zombie the polling loop — `stopPolling()` increments an epoch
+  counter and any in-flight `getExecution()` bails before
+  re-scheduling.
+
+## Cross-cutting: the DSL schema
+
+The same Pydantic models (`Playbook`, `Step`, `NextRouter`,
+`Tool`, ...) drive:
+
+- **Server validation** at `POST /api/catalog/register` — a
+  malformed playbook gets a 422 with the field path before it
+  hits the catalog
+- **Engine load** at execute time — every playbook the
+  worker picks up is reconstructed from the same model
+- **A published JSON Schema** at `noetl/core/dsl/playbook.schema.json`,
+  auto-generated from the Pydantic models via
+  `python -m noetl.core.dsl._generate_schema`. Editors that
+  read the schema URL get autocomplete and inline error
+  reporting against the canonical v10 contract.
+
+Catalog `kind` is also authoritative from the YAML payload, not
+the request parameter — `noetl catalog register
+mcp_kubernetes.yaml` correctly stores it as `kind: mcp` even
+when the CLI defaults its hint to `Playbook`.
+
+## Cross-cutting: RBAC
+
+Two service accounts, two ClusterRoles:
+
+| SA | Lives in | Granted by | What it does |
+|---|---|---|---|
+| `noetl-worker` | `noetl` namespace | `noetl-worker-lifecycle-installer` ClusterRole | helm install + kubectl create namespace + apply chart resources |
+| `kubernetes-mcp-server` | `mcp` namespace (chart-managed) | `kubernetes-mcp-server-reader` ClusterRole | read pods/events/services/etc. across all namespaces |
+
+Both are namespace-scoped Subjects bound to cluster-wide rules,
+narrowed to read for the MCP server and CRUD-on-chart-resources
+for the worker. Neither is `cluster-admin` — the broadest verbs
+each really needs.
+
+## Why dispatcher → worker → in-cluster execution
+
+A reasonable alternative is to have the noetl-server execute
+shell commands directly. We chose the dispatch path because:
+
+- **Audit trail.** Every lifecycle invocation produces the same
+  `playbook.initialized` / `command.issued` / `command.done`
+  events as a regular playbook run. No special tracing for MCP
+  ops.
+- **Backpressure.** The worker pool has admission/concurrency
+  controls. A burst of `lifecycle.status` calls from a polling
+  GUI doesn't compete with helm-driven `lifecycle.deploy` runs
+  for a single thread on the noetl-server pod.
+- **Failure isolation.** A misbehaving shell that pegs CPU or
+  burns through file descriptors hurts a worker pod, not the
+  serving pod that the GUI depends on.
+- **Consistency.** Same dispatch semantics, same retry config,
+  same error envelope as every other tool kind. Lifecycle
+  operations look like any other playbook execution from the
+  outside.
+
+## Where the architecture is going
+
+Open follow-ups (none blocking):
+
+- **Mcp tab + Add-MCP wizard** in the GUI. With the JSON schema
+  + the curated `mcp_kubernetes.yaml` template, the wizard can
+  prefill from a known-good shape and live-validate user input
+  against `playbook.schema.json` as they type.
+- **Bake the kubernetes-mcp-server reader RBAC into the chart
+  values** so a fresh `lifecycle.deploy` doesn't need a manual
+  `kubectl apply` after.
+- **Tighter cluster RBAC for the worker** by label selector or
+  namespace allowlist once helm 3.x supports the necessary
+  scoping cleanly.
+- **More MCP servers.** The catalog template shape is generic —
+  any MCP server that ships a helm chart can drop into the same
+  lifecycle agent fleet with a different `spec.deployment.chart_ref`
+  and new `spec.runtime.agent`.
+
+## Read more
+
+- [MCP End-to-End on Local Kind](../operations/mcp_end_to_end_local_kind) — full bring-up from scratch
+- [MCP End-to-End on GKE](../operations/mcp_end_to_end_gke) — same architecture in the cloud
+- [Older Kubernetes MCP runbook](../operations/kubernetes-mcp-local-kind) — pre-architecture-PR, kept for context
+- [Sink-driven storage](sink_driven_storage) — the event/projection pattern this builds on

--- a/docs/operations/mcp-end-to-end-gke.md
+++ b/docs/operations/mcp-end-to-end-gke.md
@@ -1,0 +1,349 @@
+---
+id: mcp-end-to-end-gke
+title: MCP End-to-End on GKE
+sidebar_label: MCP End-to-End (GKE)
+sidebar_position: 4
+---
+
+# MCP End-to-End on GKE
+
+Deploy the same NoETL + MCP architecture you ran locally
+([MCP End-to-End on Local Kind](mcp_end_to_end_local_kind)) onto a
+Google Kubernetes Engine cluster.
+
+The shape of the deployment is identical:
+
+- noetl-server + noetl-worker in the `noetl` namespace
+- noetl-gui in the `gui` namespace
+- kubernetes-mcp-server in the `mcp` namespace, deployed *through*
+  noetl's lifecycle dispatch (so the catalog browser can manage it)
+- postgres + nats as state stores
+
+What changes for GKE:
+
+- the cluster doesn't necessarily expose itself to the public
+  internet; we use port-forwards or an Ingress with IAP
+- container runtime is GKE-managed (no podman); local source
+  builds aren't useful, we always pull from `ghcr.io/noetl/...`
+- persistence uses GCP-managed storage (PD, optionally Cloud SQL)
+  rather than hostPath mounts
+- the gateway component (Rust auth proxy) is recommended as
+  the front door so the GUI's session-token flow works without
+  IP-based access controls
+
+## Prerequisites
+
+| Tool | Use |
+|---|---|
+| `gcloud` ≥ 470 | GCP control |
+| `kubectl` ≥ 1.27 | k8s control |
+| `helm` ≥ 3.13 | chart installs |
+| `gh` ≥ 2.40 | release lookups |
+| `noetl` (rust CLI) | catalog register / register from local YAMLs |
+
+GCP-side prep:
+
+```bash
+gcloud auth login
+gcloud config set project <YOUR_PROJECT_ID>
+gcloud config set compute/region us-central1
+gcloud services enable container.googleapis.com containerregistry.googleapis.com
+```
+
+## Step 1 — Create the GKE cluster
+
+For development workloads, a small Autopilot cluster is the
+cheapest thing that works (~$70/mo idle, scales to zero on
+namespaces without active workloads):
+
+```bash
+gcloud container clusters create-auto noetl-mcp \
+  --region=us-central1 \
+  --release-channel=regular
+gcloud container clusters get-credentials noetl-mcp --region=us-central1
+kubectl config rename-context "gke_$(gcloud config get-value project)_us-central1_noetl-mcp" gke-noetl-mcp
+kubectl config use-context gke-noetl-mcp
+kubectl get nodes
+```
+
+For Standard (more control over node pools, persistent volumes,
+RBAC node-affinity), see [GKE Autopilot Full Provisioning](../features/gke_autopilot_full_provisioning)
+for a pre-built playbook.
+
+## Step 2 — Bootstrap postgres + nats
+
+Two paths.
+
+**Cluster-internal Postgres** (cheaper for dev, lives or dies with
+the cluster):
+
+```bash
+cd repos/noetl
+kubectl apply -f ci/manifests/postgres/namespace/namespace.yaml
+kubectl create configmap postgres-schema-ddl \
+  --namespace postgres \
+  --from-file=schema_ddl.sql.norun=noetl/database/ddl/postgres/schema_ddl.sql \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f ci/manifests/postgres/
+kubectl rollout status deployment/postgres -n postgres --timeout=300s
+```
+
+**Cloud SQL with Private IP via PgBouncer** (recommended for
+anything you don't want to lose with `kubectl delete ns`):
+follow [GCP Cloud SQL + PgBouncer Private IP](gcp-cloudsql-pgbouncer-private-ip).
+The noetl-server's Postgres connection string then points at the
+in-cluster pgbouncer service instead of `postgres.postgres.svc...`.
+
+**NATS** is identical to local kind:
+
+```bash
+kubectl apply -f ci/manifests/nats/
+kubectl rollout status statefulset/nats -n nats --timeout=300s
+```
+
+## Step 3 — Apply RBAC + deploy noetl
+
+The same `rbac.yaml` from local kind ships the
+`noetl-worker-lifecycle-installer` ClusterRole — it works
+unchanged on GKE.
+
+```bash
+NOETL_TAG=$(gh release list --repo noetl/noetl --limit 1 --json tagName -q '.[0].tagName')
+TARGET_IMAGE="ghcr.io/noetl/noetl:${NOETL_TAG}"
+
+kubectl apply -f ci/manifests/noetl/namespace/
+if ! kubectl get secret gcs-credentials -n noetl >/dev/null 2>&1; then
+  # Real GCS credentials live here in production. The placeholder
+  # is only good enough for non-GCS-backed playbooks.
+  kubectl create secret generic gcs-credentials -n noetl \
+    --from-literal=gcs-key.json='{}'
+fi
+kubectl apply -f ci/manifests/noetl/rbac.yaml
+
+for manifest in ci/manifests/noetl/*.yaml; do
+  if [ -f "$manifest" ]; then
+    sed -e "s|image_name:image_tag|${TARGET_IMAGE}|g" "$manifest" | kubectl apply -f -
+  fi
+done
+
+# imagePullPolicy=Always so GKE pulls from ghcr on each rollout
+for d in noetl-server noetl-worker; do
+  for c in $(kubectl -n noetl get deployment "$d" -o jsonpath='{.spec.template.spec.containers[*].name}'); do
+    kubectl -n noetl patch deployment "$d" --type=strategic -p \
+      "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"${c}\",\"imagePullPolicy\":\"Always\"}]}}}}"
+  done
+done
+
+kubectl -n noetl rollout status deployment/noetl-server --timeout=300s
+kubectl -n noetl rollout status deployment/noetl-worker --timeout=300s
+```
+
+## Step 4 — Reach the noetl API
+
+GKE clusters typically aren't exposed publicly. Three options:
+
+**Port-forward** (simplest for dev):
+
+```bash
+kubectl -n noetl port-forward svc/noetl 8082:8082 > /tmp/noetl-pf.log 2>&1 &
+sleep 2
+curl -fsS http://localhost:8082/api/health
+```
+
+**Ingress + Identity-Aware Proxy (IAP)** (recommended for shared
+dev clusters): follow [GKE User Guide](../iap-gcp/gke_user_guide).
+The gateway component then sits behind IAP and the GUI uses its
+session-token flow as normal.
+
+**Internal LoadBalancer** (cluster reachable from VPC peers):
+patch the noetl Service to `type: LoadBalancer` with
+`networking.gke.io/load-balancer-type: Internal`. The GUI's
+`api_base_url` then points at the internal LB IP.
+
+## Step 5 — Deploy the GUI
+
+Same as local kind — no special handling needed:
+
+```bash
+GUI_TAG=$(gh release list --repo noetl/gui --limit 1 --json tagName -q '.[0].tagName')
+
+# Create the namespace + the service yourself; we don't run
+# noetl_development_deploy on GKE because that script assumes podman.
+kubectl create namespace gui --dry-run=client -o yaml | kubectl apply -f -
+
+helm upgrade --install noetl-gui \
+  oci://ghcr.io/noetl/charts/noetl-gui \
+  --version "$(echo $GUI_TAG | tr -d v)" \
+  --namespace gui \
+  --set image.repository="ghcr.io/noetl/gui" \
+  --set image.tag="${GUI_TAG}" \
+  --set image.pullPolicy=Always \
+  --set service.type=ClusterIP \
+  --set api_base_url="http://noetl.noetl.svc.cluster.local:8082" \
+  --set allow_skip_auth=false \
+  --set gateway_url="https://gateway.your-domain.com"
+
+kubectl -n gui rollout status deployment/gui --timeout=300s
+```
+
+For dev clusters without the gateway, set `allow_skip_auth=true`
+and point `api_base_url` at whatever exposes the noetl service to
+the GUI's browser (commonly an IAP-protected ingress).
+
+## Step 6 — Register the MCP catalog content
+
+This step is **identical** to local kind — the catalog is
+server-side, the noetl CLI just talks to whatever API it's
+configured against. Either:
+
+- run `noetl catalog register` from your laptop with `--host`
+  pointing at the GKE service's port-forward, or
+- run it from a one-off `noetl` CLI pod inside the cluster
+  (the noetl image ships the rust binary at `/usr/local/bin/noetl`).
+
+```bash
+# Option A — from the laptop with port-forward active
+NOETL_HOST=localhost NOETL_PORT=8082 \
+  noetl catalog register repos/ops/automation/agents/kubernetes/templates/mcp_kubernetes.yaml
+# (and the six lifecycle files; same loop as local kind step 6)
+```
+
+## Step 7 — Deploy the Kubernetes MCP server via lifecycle.deploy
+
+Same dispatch path as local kind:
+
+```bash
+curl -s -X POST http://localhost:8082/api/mcp/mcp/kubernetes/lifecycle/deploy \
+  -H "Content-Type: application/json" -d '{}' | python3 -m json.tool
+sleep 75
+kubectl -n mcp get all
+```
+
+GKE's image pull is faster than kind on Apple Silicon (no QEMU);
+the entire helm install + pod-pull cycle usually completes in
+under 60 seconds.
+
+## Step 8 — Cluster-read RBAC for the MCP server SA
+
+Same manual binding as local kind until the chart values are
+fixed:
+
+```bash
+cat <<'YAML' | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-mcp-server-reader
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "nodes", "pods", "pods/log", "services", "endpoints", "configmaps", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-mcp-server-reader
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-mcp-server
+    namespace: mcp
+roleRef:
+  kind: ClusterRole
+  name: kubernetes-mcp-server-reader
+  apiGroup: rbac.authorization.k8s.io
+YAML
+```
+
+## GKE-specific gotchas
+
+### Workload Identity
+
+If your GKE cluster has Workload Identity enabled (the default for
+Autopilot), the noetl-worker SA can be bound to a GCP IAM service
+account, eliminating the need for in-cluster GCS credentials.
+Replace the placeholder secret in step 3 with:
+
+```bash
+gcloud iam service-accounts create noetl-worker \
+  --display-name="NoETL distributed worker"
+gcloud projects add-iam-policy-binding $(gcloud config get-value project) \
+  --member="serviceAccount:noetl-worker@$(gcloud config get-value project).iam.gserviceaccount.com" \
+  --role="roles/storage.objectViewer"
+gcloud iam service-accounts add-iam-policy-binding \
+  "noetl-worker@$(gcloud config get-value project).iam.gserviceaccount.com" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:$(gcloud config get-value project).svc.id.goog[noetl/noetl-worker]"
+kubectl annotate serviceaccount noetl-worker -n noetl \
+  "iam.gke.io/gcp-service-account=noetl-worker@$(gcloud config get-value project).iam.gserviceaccount.com"
+kubectl rollout restart deployment/noetl-worker -n noetl
+```
+
+### Image pull from a private ghcr
+
+If the noetl images are private on ghcr (the default for
+non-public-org images), create an imagePullSecret in each
+namespace that pulls from ghcr:
+
+```bash
+kubectl create secret docker-registry ghcr-pull \
+  --docker-server=ghcr.io \
+  --docker-username=<your-github-user> \
+  --docker-password=<a github token with read:packages> \
+  --namespace noetl
+kubectl create secret docker-registry ghcr-pull \
+  --docker-server=ghcr.io \
+  --docker-username=<your-github-user> \
+  --docker-password=<token> \
+  --namespace gui
+```
+
+…and patch the deployments to reference it:
+
+```bash
+for ns in noetl gui mcp; do
+  kubectl -n "$ns" patch serviceaccount default \
+    -p '{"imagePullSecrets":[{"name":"ghcr-pull"}]}'
+done
+```
+
+### Network policies and the MCP server
+
+If you're running with a default-deny NetworkPolicy, the noetl
+worker needs egress to the MCP server's ClusterIP and to the
+public internet (helm pulls OCI charts and image registries).
+Allow:
+
+- `noetl/noetl-worker → mcp/kubernetes-mcp-server:8080`
+- `noetl/noetl-worker → 0.0.0.0/0:443` (for OCI chart + image pulls)
+
+### Persistent storage
+
+Host-path mounts in the kind config don't apply on GKE. Postgres
+and noetl data both want StatefulSet PVCs. The default manifests
+ship `storageClassName: standard` which Autopilot maps to
+`pd-balanced`. For production, override to `premium-rwo` and
+size up `pgdata` past 5Gi.
+
+## Verify
+
+Open the GUI (port-forward, IAP-protected ingress, or internal
+LoadBalancer URL — whichever you set up in step 4 / 5), navigate
+to `mcp/kubernetes`, click `pods`. Real GKE cluster pods should
+stream back through the friendly run dialog.
+
+## Related documentation
+
+- [MCP catalog architecture overview](../architecture/mcp_catalog_architecture)
+- [MCP End-to-End on Local Kind](mcp_end_to_end_local_kind)
+- [GKE Autopilot Full Provisioning](../features/gke_autopilot_full_provisioning)
+- [GKE User Guide](../iap-gcp/gke_user_guide)
+- [GCP Cloud SQL + PgBouncer Private IP](gcp-cloudsql-pgbouncer-private-ip)

--- a/docs/operations/mcp-end-to-end-local-kind.md
+++ b/docs/operations/mcp-end-to-end-local-kind.md
@@ -1,0 +1,313 @@
+---
+id: mcp-end-to-end-local-kind
+title: MCP End-to-End on Local Kind
+sidebar_label: MCP End-to-End (Local Kind)
+sidebar_position: 3
+---
+
+# MCP End-to-End on Local Kind
+
+Step-by-step bring-up of the full NoETL stack on a local
+[kind](https://kind.sigs.k8s.io/) cluster, ending with a
+**`kubernetes-mcp-server`** pod reachable from the GUI's friendly
+run dialog. After this guide finishes you'll be able to open
+`http://localhost:38081/`, click `mcp/kubernetes` → `pods`, and see
+real cluster state stream back through the GUI.
+
+The architecture this guide deploys is described in detail under
+[NoETL Catalog-Driven MCP Architecture](../architecture/mcp_catalog_architecture).
+
+## What you end up with
+
+```mermaid
+flowchart LR
+  GUI["GUI catalog browser<br/>http://localhost:38081/"] -->|click verb| Server["noetl-server<br/>noetl namespace"]
+  Server -->|dispatch| Worker["noetl-worker<br/>noetl namespace"]
+  Worker -->|kind:shell + helm| MCP["kubernetes-mcp-server<br/>mcp namespace"]
+  Worker -->|kind:mcp + tools/call| MCP
+  MCP -->|kubectl SA| API["kind cluster API"]
+  Server -->|events| GUI
+```
+
+| Pod | Namespace | Image |
+|---|---|---|
+| `noetl-server` | `noetl` | `ghcr.io/noetl/noetl:v2.29.x` (or later) |
+| `noetl-worker` | `noetl` | same |
+| `noetl-gui` | `gui` | `ghcr.io/noetl/gui:v1.3.x` |
+| `kubernetes-mcp-server` | `mcp` | `quay.io/containers/kubernetes_mcp_server:v0.0.61` |
+| `postgres` | `postgres` | upstream postgres |
+| `nats` | `nats` | upstream nats |
+
+## Prerequisites
+
+| Tool | Version | macOS install |
+|---|---|---|
+| podman (or Docker Desktop) | ≥ 4 | `brew install podman` then `podman machine init && podman machine start` |
+| kind | ≥ 0.20 | `brew install kind` |
+| kubectl | ≥ 1.27 | `brew install kubectl` |
+| helm | ≥ 3.13 | `brew install helm` |
+| gh | ≥ 2.40 | `brew install gh` |
+| noetl CLI (rust) | latest | `brew install noetl/tap/noetl` (or build from `repos/cli`) |
+
+Repositories — clone the AI-meta monorepo with submodules:
+
+```bash
+git clone --recurse-submodules git@github.com:noetl/ai-meta.git
+cd ai-meta
+git submodule update --init --recursive
+```
+
+After this, you have:
+
+- `repos/noetl` — server / worker source + manifests
+- `repos/ops`   — automation playbooks (kind bootstrap, deploy helpers, MCP lifecycle agents)
+- `repos/gui`   — web UI source
+
+## Step 1 — Create the kind cluster
+
+The cluster config in `repos/ops/ci/kind/config.yaml` ships the
+nodePort mappings (8082 noetl, 38081 gui, 30888 superset, etc.) and
+hostPath mounts that survive cluster recreations:
+
+```bash
+cd ai-meta/repos/ops
+kind create cluster --config=ci/kind/config.yaml
+kubectl config use-context kind-noetl
+kubectl cluster-info
+```
+
+Expected: `kind-noetl` shows as the active context, `cluster-info`
+returns the control-plane URL, and `kubectl get nodes` shows one
+`noetl-control-plane` node.
+
+## Step 2 — Bootstrap postgres + nats
+
+These are dependencies of the noetl server. Apply the manifests:
+
+```bash
+cd ai-meta/repos/noetl
+
+# Postgres
+kubectl apply -f ci/manifests/postgres/namespace/namespace.yaml
+kubectl create configmap postgres-schema-ddl \
+  --namespace postgres \
+  --from-file=schema_ddl.sql.norun=noetl/database/ddl/postgres/schema_ddl.sql \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f ci/manifests/postgres/
+
+# NATS
+kubectl apply -f ci/manifests/nats/
+
+kubectl rollout status deployment/postgres -n postgres --timeout=180s
+kubectl rollout status statefulset/nats -n nats --timeout=180s
+```
+
+## Step 3 — Deploy noetl from the registry image
+
+Use the latest published image — no local source build needed:
+
+```bash
+NOETL_TAG=$(gh release list --repo noetl/noetl --limit 1 --json tagName -q '.[0].tagName')
+echo "Deploying ${NOETL_TAG}"
+
+# Apply namespace + RBAC + manifests
+kubectl apply -f ci/manifests/noetl/namespace/
+if ! kubectl get secret gcs-credentials -n noetl >/dev/null 2>&1; then
+  kubectl create secret generic gcs-credentials -n noetl --from-literal=gcs-key.json='{}'
+fi
+kubectl apply -f ci/manifests/noetl/rbac.yaml
+
+# Substitute the image placeholder and apply
+TARGET_IMAGE="ghcr.io/noetl/noetl:${NOETL_TAG}"
+for manifest in ci/manifests/noetl/*.yaml; do
+  if [ -f "$manifest" ]; then
+    sed -e "s|image_name:image_tag|${TARGET_IMAGE}|g" "$manifest" | kubectl apply -f -
+  fi
+done
+
+# imagePullPolicy=Always so kind actually pulls from ghcr
+for d in noetl-server noetl-worker; do
+  for c in $(kubectl -n noetl get deployment "$d" -o jsonpath='{.spec.template.spec.containers[*].name}'); do
+    kubectl -n noetl patch deployment "$d" --type=strategic -p \
+      "{\"spec\":{\"template\":{\"spec\":{\"containers\":[{\"name\":\"${c}\",\"imagePullPolicy\":\"Always\"}]}}}}"
+  done
+done
+kubectl -n noetl rollout status deployment/noetl-server --timeout=240s
+kubectl -n noetl rollout status deployment/noetl-worker --timeout=240s
+```
+
+## Step 4 — Port-forward and health-check
+
+```bash
+kubectl -n noetl port-forward svc/noetl 8082:8082 > /tmp/noetl-pf.log 2>&1 &
+sleep 2
+curl -fsS http://localhost:8082/api/health && echo "  noetl reachable"
+```
+
+Expected: `{"status":"ok"}`.
+
+## Step 5 — Deploy the GUI
+
+```bash
+cd ai-meta/repos/ops
+GUI_TAG=$(gh release list --repo noetl/gui --limit 1 --json tagName -q '.[0].tagName')
+echo "Deploying gui ${GUI_TAG}"
+
+noetl run automation/development/gui.yaml --runtime local \
+  --set action=deploy \
+  --set image_repository=ghcr.io/noetl/gui \
+  --set image_tag="${GUI_TAG}" \
+  --set image_pull_policy=Always \
+  --set api_base_url=http://localhost:8082 \
+  --set allow_skip_auth=true
+
+# Watch the rollout (deployment is named `gui`, not `noetl-gui`)
+kubectl -n gui rollout status deployment/gui --timeout=180s
+```
+
+Open the GUI at `http://localhost:38081/` — you should land in the
+catalog browser.
+
+## Step 6 — Register the MCP catalog content
+
+The lifecycle agents and the curated `mcp_kubernetes.yaml` template
+ship in `repos/ops` and need to be registered into the running
+catalog:
+
+```bash
+cd ai-meta/repos/ops
+for f in \
+  automation/agents/kubernetes/runtime.yaml \
+  automation/agents/kubernetes/lifecycle/deploy.yaml \
+  automation/agents/kubernetes/lifecycle/undeploy.yaml \
+  automation/agents/kubernetes/lifecycle/redeploy.yaml \
+  automation/agents/kubernetes/lifecycle/restart.yaml \
+  automation/agents/kubernetes/lifecycle/status.yaml \
+  automation/agents/kubernetes/lifecycle/discover.yaml \
+  automation/agents/kubernetes/templates/mcp_kubernetes.yaml ; do
+  echo "=== $f ==="
+  noetl catalog register "$f"
+done
+```
+
+Expected: each call returns `version 1 registered` (or higher on
+re-runs). The Mcp template registers as `kind: mcp`; everything else
+as `kind: playbook`.
+
+## Step 7 — Deploy the Kubernetes MCP server via lifecycle.deploy
+
+This is the dispatcher path — every wire from catalog browser
+through to a real cluster effect:
+
+```bash
+DEPLOY_RESP=$(curl -s -X POST http://localhost:8082/api/mcp/mcp/kubernetes/lifecycle/deploy \
+  -H "Content-Type: application/json" -d '{}')
+echo "$DEPLOY_RESP" | python3 -m json.tool
+DEPLOY_EXEC=$(echo "$DEPLOY_RESP" | python3 -c 'import json,sys; print(json.load(sys.stdin)["execution_id"])')
+sleep 75
+kubectl -n mcp get all
+```
+
+Expected:
+- `deployment.apps/kubernetes-mcp-server` Available 1/1
+- `pod/kubernetes-mcp-server-...` Running
+- `service/kubernetes-mcp-server` ClusterIP
+
+## Step 8 — Bind cluster-read RBAC for the MCP server SA
+
+The kubernetes-mcp-server reads pods/events/etc across the cluster
+through its own service account. Until [this is baked into the
+chart values](https://github.com/noetl/noetl/issues), bind a
+read-only ClusterRole to it manually:
+
+```bash
+cat <<'YAML' | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernetes-mcp-server-reader
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "nodes", "pods", "pods/log", "services", "endpoints", "persistentvolumeclaims", "configmaps", "events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-mcp-server-reader
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-mcp-server
+    namespace: mcp
+roleRef:
+  kind: ClusterRole
+  name: kubernetes-mcp-server-reader
+  apiGroup: rbac.authorization.k8s.io
+YAML
+
+kubectl auth can-i list pods --all-namespaces \
+  --as=system:serviceaccount:mcp:kubernetes-mcp-server
+# Expect: yes
+```
+
+## Step 9 — Verify end-to-end from the GUI
+
+1. Open `http://localhost:38081/`.
+2. In the prompt, type `cd /mcp/kubernetes` then `ls`.
+3. Click the **`pods`** action chip.
+4. Wait for the execution to complete — the run dialog shows pod
+   data streamed back from the MCP server.
+5. Try `namespaces`, `events`, `top`. All should return real
+   cluster data.
+
+If you see a permission-denied error from the MCP server, return
+to step 8.
+
+## Troubleshooting
+
+### `noetl catalog register` returns connection refused
+
+Your port-forward died. Restart it:
+
+```bash
+pkill -f 'kubectl.*port-forward.*noetl' 2>/dev/null
+kubectl -n noetl port-forward svc/noetl 8082:8082 > /tmp/noetl-pf.log 2>&1 &
+```
+
+### lifecycle.deploy returns `failed: True` but pod is running
+
+Known cosmetic — the helm install completed, the pod is up, but the
+agent's post-install assertion reported failure. The MCP server is
+usable; track the agent fix in [issue #79](https://github.com/noetl/noetl/issues).
+
+### `cd /mcp/kubernetes && ls` doesn't work
+
+The GUI prompt parser treats `&&` as part of the cd argument. Use
+two commands separated by an Enter press until the parser is fixed.
+
+### Worker fails with `Tool kind 'shell' not implemented`
+
+You're on a noetl image older than v2.29.0. Roll forward.
+
+### `helm: not found` inside the worker
+
+You're on a noetl image older than v2.28.0. Roll forward.
+
+## Related documentation
+
+- [MCP catalog architecture overview](../architecture/mcp_catalog_architecture)
+- [GKE deployment guide](mcp_end_to_end_gke)
+- [Local Kind Deployment (general)](local-kind-ops-deploy)
+- [Kubernetes MCP Local Kind Setup (older runbook)](kubernetes-mcp-local-kind)


### PR DESCRIPTION
docs(mcp): add end-to-end runbooks (local kind + GKE) + architecture overview

Three new pages under noetl.dev:

1. operations/mcp-end-to-end-local-kind.md
   Full bring-up of the catalog-driven MCP architecture on a local
   kind cluster. Step 1 (kind create) through step 9 (click `pods`
   in the GUI and watch real cluster state stream back). Includes
   the manual kubernetes-mcp-server-reader ClusterRoleBinding that
   patches around the chart's extraClusterRoles values gap, and
   troubleshooting for the common failure modes (port-forward
   died, lifecycle.deploy reports failed: True despite pod
   running, prompt parser doesn't accept &&).

2. operations/mcp-end-to-end-gke.md
   GKE-specific variant. Same architecture, different surrounding
   infra: gcloud cluster create, ImagePullSecrets for private
   ghcr, Workload Identity binding for the worker SA, IAP-fronted
   ingress for the GUI, internal LoadBalancer for in-VPC access.
   Cross-references the existing GKE Autopilot Full Provisioning
   playbook for cluster bootstrap.

3. architecture/mcp_catalog_architecture.md
   The "presentation" — what the architecture is and why this
   shape. Walks through the four phases (Mcp resource lifecycle,
   server-side check_playbook_access, lifecycle agents,
   friendly run dialog), the cross-cutting pieces (DSL schema,
   RBAC, dispatcher → worker rationale), and the open
   follow-ups. Suitable for a noetl.dev landing-area read; links
   into the two operations runbooks for the practical bring-up.

All three follow the docusaurus front-matter convention (`id`,
`title`, `sidebar_label`, `sidebar_position`) and land in
auto-generated sidebar categories — no sidebars.ts changes
needed.

Refs: noetl/noetl#392, #393, #394, #395, #396, #397, #398,
      #399, #400, #401; noetl/ops#15, #16, #17, #18;
      noetl/gui#16, #17, #18, #19.
