### PR TITLE
docs(mcp): document managed GKE MCP and private exposure

### DIFF
--- a/docs/architecture/mcp_catalog_architecture.md
+++ b/docs/architecture/mcp_catalog_architecture.md
@@ -125,6 +125,15 @@ Every block describes intent rather than commands:
 - `spec.runtime.agent` — which playbook the GUI calls when a user invokes a tool
 - `spec.deployment` — knobs the lifecycle agents read at install time
 
+Managed MCP providers use the same catalog shape without a deploy
+lifecycle. For example, the Google Cloud GKE managed endpoint is
+registered as `kind: Mcp` at `mcp/gcp`, points at
+`https://container.googleapis.com/mcp/read-only`, and uses the
+terminal agent playbook `mcp/gcp/gke`. No pod is installed in the
+cluster; the NoETL worker obtains a Google Cloud access token through
+Workload Identity or an explicit execution workload override, calls
+the managed endpoint, and records the response as a normal execution.
+
 The server exposes:
 
 - `POST /api/mcp/{path}/lifecycle/{verb}` — dispatch a lifecycle agent

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -52,6 +52,7 @@ Both windows can be hidden, shown, maximized, and resized. Hiding the console le
 | `cd /mcp/<name>` | Navigate to a registered MCP workspace, such as `/mcp/kubernetes`. |
 | `mcp status` | Launch the selected workspace agent playbook to inspect MCP availability and tool count. |
 | `mcp tools` | Launch the selected workspace agent playbook to list exposed MCP tools. |
+| `call <tool> [payload]` | Inside `/mcp/<name>`, invoke an MCP tool through the selected workspace agent. Payload can be JSON or `--set key=value` pairs. |
 | `k8s pods [namespace]` | Launch the registered Kubernetes runtime agent playbook and list pods. |
 | `k8s namespaces` | Launch the registered Kubernetes runtime agent playbook and list namespaces. |
 | `k8s events [namespace]` | Launch the registered Kubernetes runtime agent playbook and list Kubernetes events. |
@@ -95,6 +96,23 @@ Inside `/mcp/kubernetes`, Kubernetes commands can be typed without the `k8s` pre
 
 The older global forms, such as `k8s pods noetl`, remain valid from any workspace. The scoped form keeps the terminal closer to a filesystem shell: move to the resource scope first, then run the verbs that are valid for that scope.
 
+Generic MCP scopes, such as `/mcp/gcp`, support the same execution path even
+when the GUI does not know provider-specific verbs:
+
+| Command | Description |
+|---|---|
+| `status` | Run the workspace agent with `tools/list` and show the execution ID plus tool count. |
+| `tools` | Print the exposed tool names and descriptions. |
+| `call <tool> [payload]` | Invoke a specific MCP tool through the workspace agent. |
+
+Example:
+
+```text
+noetl@kind:/mcp$ cd /mcp/gcp
+noetl@kind:/mcp/gcp$ tools
+noetl@kind:/mcp/gcp$ call list_clusters --set parent=projects/noetl-demo-19700101/locations/-
+```
+
 ## Clickable Results
 
 Console output can include clickable actions. For example:
@@ -118,6 +136,8 @@ noetl@kind:/editor$ open execution
 noetl@kind:/execution$ open 612955956145554347
 noetl@kind:/catalog$ cd /mcp/kubernetes
 noetl@kind:/mcp/kubernetes$ pods noetl
+noetl@kind:/mcp$ cd /mcp/gcp
+noetl@kind:/mcp/gcp$ call list_clusters --set parent=projects/noetl-demo-19700101/locations/-
 ```
 
 ## Payloads

--- a/docs/operations/gcp-current-setup-system-playbooks.md
+++ b/docs/operations/gcp-current-setup-system-playbooks.md
@@ -236,7 +236,29 @@ noetl --server-url http://localhost:18082 register playbook \
   -f fixtures/playbooks/api_integration/auth0/setup_admin_permissions.yaml
 ```
 
-### 3. Validate schema/role data
+### 3. Register managed GKE MCP content
+
+For the Google Cloud managed GKE MCP endpoint, register the runtime
+agent and `Mcp` resource from `repos/ops`:
+
+```bash
+cd repos/ops
+
+noetl --server-url http://localhost:18082 catalog register \
+  automation/agents/gcp/runtime.yaml
+noetl --server-url http://localhost:18082 catalog register \
+  automation/agents/gcp/templates/mcp_gke_managed.yaml
+```
+
+The GUI terminal discovers this as `/mcp/gcp`. It does not call
+Google Cloud directly; `status`, `tools`, and `call <tool>` start
+NoETL executions for the `mcp/gcp/gke` agent playbook. The worker
+needs Google Cloud credentials through Workload Identity, a
+`GOOGLE_OAUTH_ACCESS_TOKEN` environment override, or a one-off
+`workload.access_token` for local debugging. Prefer Workload Identity
+with `roles/container.viewer`.
+
+### 4. Validate schema/role data
 
 ```bash
 kubectl exec -n postgres deploy/pgbouncer -- sh -lc 'echo "Use Cloud SQL client path for deep DB checks"'
@@ -248,13 +270,13 @@ kubectl exec -n postgres deploy/pgbouncer -- sh -lc 'echo "Use Cloud SQL client 
 # FROM auth.playbook_permissions ORDER BY role_id;
 ```
 
-### 4. Verify session cache path
+### 5. Verify session cache path
 
 - Login through Gateway UI/API
 - Confirm `auth.sessions` row exists in Postgres
 - Confirm `sessions` bucket entry exists in NATS KV
 
-### 5. Verify browser login through Gateway
+### 6. Verify browser login through Gateway
 
 Use an Auth0 ID token from the browser session or Auth0 tooling. Do not put passwords in shell commands or logs.
 

--- a/docs/operations/gke-cloudsql-end-to-end.md
+++ b/docs/operations/gke-cloudsql-end-to-end.md
@@ -420,6 +420,109 @@ services
 events
 ```
 
+For Google Cloud's managed GKE MCP endpoint, register the remote-managed
+resource and agent instead of deploying an in-cluster MCP server:
+
+```bash
+cd /path/to/ai-meta/repos/ops
+
+noetl catalog register automation/agents/gcp/runtime.yaml
+noetl catalog register automation/agents/gcp/templates/mcp_gke_managed.yaml
+```
+
+Then bind the NoETL worker service account to a Google service account with
+`roles/container.viewer` so the worker can obtain a token through Workload
+Identity. The GUI terminal discovers this as `/mcp/gcp`:
+
+```text
+cd /mcp/gcp
+status
+tools
+call list_clusters --set parent=projects/<project-id>/locations/-
+```
+
+## Internet Exposure Model
+
+The preferred production shape is:
+
+- GUI is static and public on Cloudflare Pages or an equivalent static host.
+- Gateway is the only public API surface.
+- NoETL server, workers, NATS, PgBouncer, Cloud SQL, and MCP services are not
+  internet-addressable.
+
+This keeps the browser-facing assets close to users while the GKE cluster
+remains an internal execution fabric.
+
+### Option A: GUI on Cloudflare Pages, Gateway in GKE
+
+Use this when you want the least deployment change from the current
+`mestumre.dev` setup:
+
+1. Build `repos/gui` with gateway mode.
+2. Deploy the static `dist/` output to Cloudflare Pages.
+3. Configure GUI runtime env:
+
+```javascript
+window.__NOETL_ENV__ = {
+  VITE_API_MODE: "gateway",
+  VITE_API_BASE_URL: "https://gateway.example.com/noetl",
+  VITE_GATEWAY_URL: "https://gateway.example.com",
+  VITE_ALLOW_SKIP_AUTH: "false",
+  VITE_AUTH0_REDIRECT_URI: "https://app.example.com/login"
+};
+```
+
+4. Expose only the Gateway service publicly. Keep `noetl/noetl` as
+   `ClusterIP` and do not create a public Ingress or LoadBalancer for it.
+5. Set Gateway CORS to the Cloudflare Pages origin:
+
+```text
+CORS_ALLOWED_ORIGINS=https://app.example.com,https://gateway.example.com
+NOETL_BASE_URL=http://noetl.noetl.svc.cluster.local:8082
+GATEWAY_AUTH_BYPASS=false
+```
+
+### Option B: GUI on Cloudflare Pages, Gateway on Cloud Run
+
+Use this when the GKE cluster should have no public Services at all:
+
+1. Deploy Gateway to Cloud Run with `GATEWAY_AUTH_BYPASS=false`.
+2. Give Cloud Run private egress to the VPC that contains the GKE cluster.
+   Google Cloud supports Cloud Run egress to VPC networks through Direct VPC
+   egress or Serverless VPC Access.
+3. Expose NoETL inside GKE through an internal-only endpoint reachable from
+   that VPC, such as an internal LoadBalancer service.
+4. Point Gateway at the internal NoETL address:
+
+```text
+NOETL_BASE_URL=http://<internal-noetl-address>:8082
+CORS_ALLOWED_ORIGINS=https://app.example.com,https://gateway.example.com
+GATEWAY_PUBLIC_URL=https://gateway.example.com
+```
+
+5. Keep GUI runtime pointing at the public Gateway URL, never at NoETL.
+
+This option gives the cleanest isolation boundary: Cloudflare serves GUI,
+Cloud Run authenticates and proxies, and GKE remains private runtime only.
+
+### Exposure checks
+
+After deployment, this should be true:
+
+```bash
+kubectl -n noetl get svc noetl
+kubectl -n noetl get ingress
+kubectl -n gui get svc,ingress
+kubectl -n gateway get svc,ingress
+```
+
+Expected:
+
+- `noetl/noetl` is `ClusterIP`
+- no public Ingress in `noetl`
+- no public GUI service when the GUI is on Cloudflare Pages
+- exactly one public Gateway endpoint, or none in GKE when Gateway is on Cloud Run
+
 ## Rollback
 
 Gateway:

--- a/docs/operations/mcp-end-to-end-gke.md
+++ b/docs/operations/mcp-end-to-end-gke.md
@@ -208,7 +208,74 @@ NOETL_HOST=localhost NOETL_PORT=8082 \
 # (and the six lifecycle files; same loop as local kind step 6)
 ```
 
-## Step 7 — Deploy the Kubernetes MCP server via lifecycle.deploy
+### Option B — Register Google Cloud's managed GKE MCP endpoint
+
+Google Cloud also exposes a [managed GKE MCP server](https://docs.cloud.google.com/kubernetes-engine/docs/reference/mcp)
+at `https://container.googleapis.com/mcp/read-only`. This option does
+not deploy a pod in the `mcp` namespace. It registers a NoETL
+`Mcp` resource plus a terminal-visible agent playbook under
+`/mcp/gcp`; every terminal call still becomes a normal NoETL
+execution recorded in `noetl.event`, `noetl.command`, and the
+`noetl.execution` projection.
+
+Register the managed resource and runtime agent:
+
+```bash
+cd repos/ops
+
+noetl catalog register automation/agents/gcp/runtime.yaml
+noetl catalog register automation/agents/gcp/templates/mcp_gke_managed.yaml
+```
+
+The worker that runs the agent needs a Google Cloud access token.
+The playbook resolves one in this order:
+
+1. `workload.access_token` passed to the execution (use only for
+   local one-off debugging)
+2. `GOOGLE_OAUTH_ACCESS_TOKEN` in the worker environment
+3. the GKE metadata server for the worker pod's service account
+
+For GKE Workload Identity, bind the NoETL worker Kubernetes
+service account to a Google service account with read-only GKE
+permissions:
+
+```bash
+PROJECT_ID="$(gcloud config get-value project)"
+GSA="noetl-worker-mcp@${PROJECT_ID}.iam.gserviceaccount.com"
+
+gcloud iam service-accounts create noetl-worker-mcp \
+  --display-name="NoETL worker managed GKE MCP"
+
+gcloud projects add-iam-policy-binding "${PROJECT_ID}" \
+  --member="serviceAccount:${GSA}" \
+  --role="roles/container.viewer"
+
+gcloud iam service-accounts add-iam-policy-binding "${GSA}" \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${PROJECT_ID}.svc.id.goog[noetl/noetl-worker]"
+
+kubectl annotate serviceaccount noetl-worker -n noetl \
+  "iam.gke.io/gcp-service-account=${GSA}" --overwrite
+
+kubectl rollout restart deployment/noetl-worker -n noetl
+```
+
+In the GUI terminal:
+
+```text
+cd /mcp
+cd /mcp/gcp
+status
+tools
+call list_clusters --set parent=projects/<project-id>/locations/-
+```
+
+Use the managed endpoint for cloud-level GKE inventory and
+read-only cluster diagnostics. Use the in-cluster Kubernetes MCP
+server below when you want Kubernetes API-server views from inside
+the target cluster's network.
+
+## Step 7 — Deploy the in-cluster Kubernetes MCP server via lifecycle.deploy
 
 Same dispatch path as local kind:
 


### PR DESCRIPTION
## Summary
- document managed Google Cloud GKE MCP registration and terminal usage
- expand MCP end-to-end GKE guidance with managed endpoint setup
- document Cloud SQL/GKE private exposure options, including Cloudflare-hosted GUI and Gateway-only access
- update terminal console docs for generic MCP workspace calls

## Validation
- npm run build

## Notes
- Docusaurus still reports the pre-existing broken anchor from /docs/reference/recreate-noetl-schema to /docs/reference/noetl_cli_usage#database-management; the build completes successfully.