### PR TITLE
docs(architecture): NoETL-as-AI-OS spike pages

### DIFF
--- a/docs/architecture/agent_orchestration.md
+++ b/docs/architecture/agent_orchestration.md
@@ -1,0 +1,225 @@
+---
+id: agent_orchestration
+title: Agent Orchestration in NoETL
+sidebar_label: Agent Orchestration
+sidebar_position: 3
+---
+
+# Agent Orchestration in NoETL
+
+How `tool: kind: agent` lets a NoETL playbook dispatch external agent
+runtimes — and how `framework: noetl` lets a playbook dispatch *another
+playbook* as the agent runtime, without writing any Python glue.
+
+This page is the reference for the agent contract. For the bigger
+picture (how playbooks and MCP servers compose into an AI operating
+system), see
+[NoETL Catalog-Driven MCP Architecture](./mcp_catalog_architecture.md)
+and [Playbook-as-MCP-Server](./playbook_as_mcp_server.md).
+
+## The agent envelope
+
+Every `tool: kind: agent` step returns the same shape regardless of
+the framework underneath:
+
+```json
+{
+  "status": "ok" | "error",
+  "framework": "adk" | "langchain" | "custom" | "noetl",
+  "entrypoint": "<framework-specific identifier>",
+  "data": <agent-produced output>,
+  "execution_id": "<for noetl framework: sub-playbook execution_id>",
+  "duration": <seconds>,
+  "error": {                       // only on failure
+    "kind": "agent.execution" | "agent.configuration",
+    "code": "<symbolic>",
+    "message": "<human-readable>",
+    "retryable": true | false,
+    "diagnosis": { ... }           // optional, see Auto-troubleshoot
+  }
+}
+```
+
+This single envelope is what makes "agents" compose: the caller
+doesn't need to know whether the agent was a Python ADK runtime, a
+LangChain chain, or a peer NoETL playbook. The shape is the contract.
+
+## Frameworks
+
+| `framework`  | Entrypoint shape                            | What runs                                          |
+|--------------|---------------------------------------------|----------------------------------------------------|
+| `adk`        | `pkg.module:factory_func`                   | Google ADK runtime, instantiated via the factory   |
+| `langchain`  | `pkg.module:chain_or_agent`                 | LangChain chain or agent, invoked via `.ainvoke`   |
+| `custom`     | `pkg.module:callable`                       | Any callable; signature is inspected and dispatched|
+| `noetl`      | `catalog/path/to/playbook`                  | A peer NoETL playbook, dispatched as a sub-flow    |
+
+Python-loaded frameworks (`adk`, `langchain`, `custom`) require the
+target module to be importable from the worker. They're great for
+calling out to existing Python agent code without rewriting it as a
+playbook. `noetl` is for the inverse: wrapping any registered
+playbook so it can be called as if it were an agent.
+
+## `framework: noetl` — playbook ≡ agent
+
+The simplest worked example. A "search flights" playbook already
+exists in the catalog at `api_integration/amadeus_ai_api`. Any other
+playbook can call it as an agent:
+
+```yaml
+- step: ask_amadeus
+  tool:
+    kind: agent
+    framework: noetl
+    entrypoint: api_integration/amadeus_ai_api
+    invoke_kwargs:
+      version: 2
+    payload:
+      query: "{{ user_query }}"
+  next:
+    arcs:
+      - step: render_results
+```
+
+Under the hood, the agent executor:
+
+1. Treats `entrypoint` as a catalog path (no Python import).
+2. Merges `payload` and `invoke_kwargs` into the sub-playbook's
+   workload.
+3. Dispatches via `execute_playbook_task` — the same plugin
+   `tool: kind: playbook` uses for fire-and-forget sub-execution.
+4. Normalises the plugin's `success` / `error` status into the agent
+   envelope's `ok` / `error`.
+5. Wires the sub-execution's `execution_id`, `data`, `duration` into
+   the envelope so callers can stitch it back into the event log.
+
+This is what makes "any playbook is an MCP tool" work end-to-end:
+the playbook-as-MCP-server endpoint
+([reference](./playbook_as_mcp_server.md)) takes an MCP `tools/call`
+and dispatches it via the same path.
+
+## Auto-troubleshoot on failure
+
+When a `framework: noetl` sub-playbook fails, the executor can
+optionally dispatch the
+[self-troubleshoot agent](./self_troubleshoot_agent.md) and attach
+the diagnosis directly to the error envelope. Three opt-in levers,
+in precedence order:
+
+1. **Per-task** — `task_config.on_failure.troubleshoot: true|false`
+2. **Env-level** — `NOETL_AGENT_AUTO_TROUBLESHOOT=1`
+3. **Default** — off
+
+Per-task always wins so operators can disable auto-diagnosis on
+inner-loop calls where the ~3s diagnostic call's wall-clock would
+dominate.
+
+```yaml
+- step: ask_amadeus
+  tool:
+    kind: agent
+    framework: noetl
+    entrypoint: api_integration/amadeus_ai_api
+    payload:
+      query: "{{ user_query }}"
+    on_failure:
+      troubleshoot: true
+      ollama_model: gemma2:2b
+      confidence_threshold: 0.85
+      escalate_to: openai
+```
+
+When this step fails, the response carries:
+
+```json
+{
+  "status": "error",
+  "framework": "noetl",
+  "entrypoint": "api_integration/amadeus_ai_api",
+  "execution_id": "exec-failed-1",
+  "error": {
+    "kind": "agent.execution",
+    "code": "PLAYBOOK_FAILED",
+    "message": "...",
+    "retryable": false,
+    "diagnosis": {
+      "category": "transient_5xx",
+      "confidence": 0.82,
+      "root_cause": "Amadeus sandbox returned HTTP 502",
+      "suggested_action": "Retry; if persistent, check api.amadeus.com status",
+      "source": "ollama",
+      "escalated": false
+    }
+  }
+}
+```
+
+A recursion guard prevents the troubleshoot agent from auto-diagnosing
+its own failures. If the troubleshoot agent itself fails, the original
+error envelope is returned unchanged — diagnostics augment failures,
+they never replace them.
+
+## Workload pass-through to the troubleshoot agent
+
+`on_failure` accepts the troubleshoot agent's workload knobs:
+
+| Key                    | Default                                            | What it controls                       |
+|------------------------|----------------------------------------------------|----------------------------------------|
+| `troubleshoot`         | `false`                                            | per-task opt-in (overrides env)        |
+| `troubleshoot_path`    | `automation/agents/troubleshoot/diagnose_execution`| catalog path of the diagnostic agent   |
+| `ollama_model`         | `gemma2:2b`                                        | local model for first-pass triage      |
+| `ollama_mcp_server`    | `mcp/ollama`                                       | catalog path of the Ollama MCP bridge  |
+| `confidence_threshold` | `0.7`                                              | escalate when local confidence < this  |
+| `escalate_to`          | `openai`                                           | `openai` / `claude` / `none`           |
+| `openai_credential`    | `openai_token`                                     | keychain entry for the API key         |
+| `openai_model`         | `gpt-4o-mini`                                      | OpenAI model for escalation            |
+| `noetl_url`            | `http://noetl-server.noetl.svc.cluster.local:8080` | NoETL API base for fetching events     |
+
+Unknown `on_failure` keys are ignored at the troubleshoot dispatch —
+they're filtered to the known set so an arbitrary key doesn't leak
+into the workload silently.
+
+## Configuration reference
+
+```yaml
+tool:
+  kind: agent
+
+  # One of: adk | langchain | custom | noetl
+  framework: noetl
+
+  # For framework=noetl: catalog path. Otherwise: 'pkg.module:attr'.
+  entrypoint: api_integration/amadeus_ai_api
+
+  # Catalog version pin (framework=noetl only). Default: latest.
+  version: 2
+
+  # Workload-equivalent payload merged into the sub-flow's input.
+  payload:
+    query: "{{ user_query }}"
+
+  # Extra kwargs merged on top of payload (caller-side overrides).
+  invoke_kwargs:
+    timeout_s: 30
+
+  # framework=adk|langchain|custom only:
+  entrypoint_mode: factory   # 'factory' (default) or 'callable'
+  entrypoint_args: {}        # kwargs passed to factory
+  invoke_method: run_async   # explicit method override
+
+  # Auto-troubleshoot hook (framework=noetl only).
+  on_failure:
+    troubleshoot: true
+    troubleshoot_path: automation/agents/troubleshoot/diagnose_execution
+    ollama_model: gemma2:2b
+    confidence_threshold: 0.7
+    escalate_to: openai
+```
+
+## See also
+
+- [Playbook-as-MCP-Server](./playbook_as_mcp_server.md) — the inverse:
+  expose any playbook as an MCP tool to external clients.
+- [Self-Troubleshoot Agent](./self_troubleshoot_agent.md) — what
+  `on_failure.troubleshoot: true` actually invokes.
+- [Ollama Bridge](../operations/ollama_bridge.md) — deploying the
+  cheap-first inference layer the troubleshoot agent uses.

--- a/docs/architecture/playbook_as_mcp_server.md
+++ b/docs/architecture/playbook_as_mcp_server.md
@@ -1,0 +1,218 @@
+---
+id: playbook_as_mcp_server
+title: Playbook-as-MCP-Server
+sidebar_label: Playbook-as-MCP-Server
+sidebar_position: 4
+---
+
+# Playbook-as-MCP-Server
+
+Any registered NoETL playbook can be invoked over the standard
+[Model Context Protocol](https://modelcontextprotocol.io) by any
+external client (Cursor, Claude Desktop, IDE plugins, peer NoETL
+deployments). The endpoint is:
+
+```
+POST /api/mcp/playbook/{path:path}/jsonrpc
+```
+
+This is the inverse of the existing MCP *client* in
+`noetl.tools.mcp` (which calls *out* to a remote MCP server): this
+endpoint *answers* the same protocol on top of an arbitrary
+playbook. The playbook becomes the tool; its workload becomes the
+tool's `inputSchema`; its result envelope becomes MCP content blocks.
+
+For the higher-level framing — how this fits with `tool: kind: mcp`
+catalog resources and the lifecycle endpoints — see
+[NoETL Catalog-Driven MCP Architecture](./mcp_catalog_architecture.md).
+
+## Wire shape — JSON-RPC 2.0
+
+The endpoint accepts a single JSON-RPC request per POST. Standard
+MCP methods are supported:
+
+| Method        | What it does                                                   |
+|---------------|----------------------------------------------------------------|
+| `initialize`  | Handshake; returns protocol version + capabilities             |
+| `tools/list`  | Returns the single tool this endpoint exposes (the playbook)   |
+| `tools/call`  | Dispatches the playbook synchronously, returns content blocks  |
+| `ping`        | Returns `{}`; used by clients to keep the connection warm      |
+
+### `initialize`
+
+```json
+// Request
+{ "jsonrpc": "2.0", "id": 1, "method": "initialize",
+  "params": { "protocolVersion": "2024-11-05" } }
+
+// Response
+{ "jsonrpc": "2.0", "id": 1,
+  "result": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": { "tools": { "listChanged": false } },
+    "serverInfo": { "name": "noetl-playbook-mcp", "version": "1.0" }
+  }
+}
+```
+
+The server echoes the client's `protocolVersion` if present, falling
+back to `2024-11-05`.
+
+### `tools/list`
+
+```json
+// Request
+{ "jsonrpc": "2.0", "id": 2, "method": "tools/list" }
+
+// Response
+{ "jsonrpc": "2.0", "id": 2,
+  "result": {
+    "tools": [{
+      "name": "amadeus_ai_api",
+      "description": "Search flights via the Amadeus API ...",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": { "type": "string", "description": "Natural-language flight query" }
+        },
+        "additionalProperties": true
+      }
+    }]
+  }
+}
+```
+
+One endpoint = one playbook = one tool. The tool name comes from
+`metadata.name` (slashes replaced with dots for filesystem safety),
+the description from `metadata.description`, and the `inputSchema`
+from the same `infer_ui_schema` helper that drives the GUI's
+workload form. **The MCP tool schema and the GUI form stay in sync
+— there is no separate source of truth.**
+
+### `tools/call`
+
+```json
+// Request
+{ "jsonrpc": "2.0", "id": 3, "method": "tools/call",
+  "params": {
+    "name": "amadeus_ai_api",
+    "arguments": { "query": "JFK to SFO tomorrow" }
+  }
+}
+
+// Response (success)
+{ "jsonrpc": "2.0", "id": 3,
+  "result": {
+    "content": [{ "type": "text", "text": "Found 3 flights, cheapest $284 ..." }],
+    "isError": false,
+    "_meta": {
+      "noetl_execution_id": "619162855312458297",
+      "noetl_path": "api_integration/amadeus_ai_api"
+    }
+  }
+}
+```
+
+The `_meta` field is non-standard but explicitly permitted by MCP
+spec. It lets clients stitch the call back into the NoETL event log
+when they want to.
+
+`tools/call` is **synchronous**: the endpoint dispatches the playbook
+via the standard `/api/execute` path, polls
+`/api/executions/{id}/status` every 1.5s, and returns when the
+execution reaches a terminal status (or after a 90-second ceiling, in
+which case the response carries JSON-RPC error code `-32011` with the
+execution_id in `error.data` so the client can poll separately).
+
+### Errors
+
+JSON-RPC errors travel in the response body, not the HTTP status —
+this is what MCP clients expect. The endpoint returns `200 OK` for
+all protocol-level outcomes (including failures) and only uses
+non-200 statuses for transport-level problems (malformed body,
+unhandled crashes).
+
+| Code     | Meaning                                                        |
+|----------|----------------------------------------------------------------|
+| `-32601` | Method not found (caller used an unknown method)               |
+| `-32602` | Invalid params (e.g. tool name doesn't match the advertised)   |
+| `-32603` | Internal server error                                          |
+| `-32010` | Playbook ran to completion but reported error                  |
+| `-32011` | Playbook timed out (90s ceiling); execution_id in error.data   |
+| `-32020` | Auth backend denied access (mirrors HTTP 401/403)              |
+
+Auth errors carry `error.data.http_status` so clients can branch on
+the original HTTP-level reason.
+
+## Opt-in via metadata
+
+A playbook is exposed by default. To explicitly *hide* a playbook
+from the MCP endpoint, set:
+
+```yaml
+metadata:
+  name: internal_only_playbook
+  exposes_as_mcp: false
+```
+
+`exposes_as_mcp` is a typed `Optional[bool]` field on the catalog's
+`PlaybookMetadata` Pydantic model — registration validates the shape
+at register time, so a typo like `exposes_as_mcp: "yes"` is rejected
+with HTTP 422 rather than failing later at MCP-call time. Absent or
+`true` means "expose"; explicit `false` means "hide".
+
+## Cursor / Claude Desktop integration
+
+Point an MCP client at the endpoint by adding to its config. For
+Claude Desktop's `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "noetl-amadeus": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-fetch"],
+      "env": {
+        "MCP_FETCH_URL": "https://noetl.example.com/api/mcp/playbook/api_integration/amadeus_ai_api/jsonrpc"
+      }
+    }
+  }
+}
+```
+
+Or with Cursor's `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "noetl-amadeus": {
+      "url": "https://noetl.example.com/api/mcp/playbook/api_integration/amadeus_ai_api/jsonrpc"
+    }
+  }
+}
+```
+
+Each tool you want to expose gets its own endpoint entry — one
+endpoint per playbook keeps each tool's authorization scope distinct.
+
+## What's not in scope
+
+- **Async tool calls / progress notifications.** `tools/call` is
+  synchronous. MCP spec supports streaming progress events but the
+  SSE plumbing for parent ↔ child execution events isn't wired
+  here yet (tracked separately).
+- **Multi-tool endpoints.** One endpoint = one playbook. The catalog
+  *is* the multiplexer — clients pick which endpoint to point at,
+  and each gets independent auth scope.
+- **Resource / prompt protocol methods.** Just tools. We can add
+  `resources/list` later if a use case lands; YAGNI for now.
+
+## See also
+
+- [Agent Orchestration](./agent_orchestration.md) — the inverse of
+  this: how a NoETL playbook calls another playbook as an agent.
+- [MCP Catalog Architecture](./mcp_catalog_architecture.md) — the
+  bigger picture for `kind: Mcp` catalog resources, lifecycle
+  dispatch, discovery.
+- [Self-Troubleshoot Agent](./self_troubleshoot_agent.md) — a worked
+  example of a playbook designed to be exposed via this endpoint.

--- a/docs/architecture/self_troubleshoot_agent.md
+++ b/docs/architecture/self_troubleshoot_agent.md
@@ -1,0 +1,178 @@
+---
+id: self_troubleshoot_agent
+title: Self-Troubleshoot Agent
+sidebar_label: Self-Troubleshoot Agent
+sidebar_position: 5
+---
+
+# Self-Troubleshoot Agent
+
+A NoETL playbook that diagnoses *other* failed NoETL executions:
+fetches the event log, classifies the failure with a local Ollama
+model (cheap-first), escalates to OpenAI only when the local model's
+confidence is low, returns a structured diagnosis the GUI and
+programmatic callers can both consume.
+
+The agent is the worked example for the NoETL-as-AI-OS architecture:
+it composes [`tool: agent framework=noetl`](./agent_orchestration.md),
+[playbook-as-MCP-server](./playbook_as_mcp_server.md), the
+[typed metadata](./mcp_catalog_architecture.md#metadata-fields), and
+the [Ollama bridge](../operations/ollama_bridge.md) into a single
+self-contained agent.
+
+## Why cheap-first
+
+Calling OpenAI / Claude for every failure in a fleet is slow and
+wasteful when most failures look identical to ones a 2B-parameter
+local model can classify in 200ms.
+
+| Approach                             | Latency  | Cost per failure |
+|--------------------------------------|----------|------------------|
+| OpenAI / Claude for every failure    | ~3s      | ~$0.01           |
+| Ollama-only                          | ~200ms   | $0.00            |
+| **Cheap-first with escalation**      | ~200ms*  | ~$0.001*         |
+
+\* Most failures (HTTP 5xx, transient timeouts, known patterns) stay
+on the Ollama path. Escalation runs only on novel / interesting
+failures — typically <10% in steady state.
+
+At fleet error volumes (O(thousands) per day) this is the difference
+between $0/day and ~$30/day in inference spend.
+
+## Flow
+
+```mermaid
+flowchart LR
+  fetch["fetch_events<br/>(GET /api/executions/{id})"]
+  extract["extract_failure_signal<br/>(Python: walk events,<br/>identify proximate cause)"]
+  triage["ollama_triage<br/>(MCP → mcp/ollama)"]
+  parse["parse_ollama_response<br/>(strip fences, parse JSON,<br/>clamp confidence)"]
+  hi["confidence ≥ threshold"]
+  lo["confidence &lt; threshold<br/>or escalate_to=openai"]
+  esc["escalate_openai<br/>(HTTP POST → OpenAI)"]
+  parse2["parse_openai_response"]
+  persist["persist_diagnosis<br/>(pick higher-confidence,<br/>emit envelope)"]
+
+  fetch --> extract --> triage --> parse
+  parse --> hi --> persist
+  parse --> lo --> esc --> parse2 --> persist
+```
+
+## Agent envelope
+
+```json
+{
+  "status": "ok",
+  "diagnosis": {
+    "execution_id": "619156384600293663",
+    "category": "transient_5xx",
+    "confidence": 0.82,
+    "root_cause": "Amadeus sandbox returned HTTP 500 on a well-formed query",
+    "suggested_action": "Retry; if persistent, check api.amadeus.com status page",
+    "source": "ollama",
+    "escalated": false
+  },
+  "summary": "Amadeus sandbox is temporarily unavailable; retry shortly.",
+  "text": "Amadeus sandbox is temporarily unavailable; retry shortly.",
+  "user_message": "Amadeus sandbox is temporarily unavailable; retry shortly."
+}
+```
+
+The `summary` / `text` / `user_message` fields all carry the same
+friendly one-liner, mirroring the GUI's `extractAgentText` heuristic
+so the run dialog renders it inline. `data.diagnosis` carries the
+structured form for programmatic callers (other playbooks,
+auto-dispatch hooks, CI integrations).
+
+## Workload knobs
+
+| Key                    | Default                                            | What it controls                       |
+|------------------------|----------------------------------------------------|----------------------------------------|
+| `execution_id`         | `""` (required)                                    | which failed execution to diagnose     |
+| `noetl_url`            | `http://noetl-server.noetl.svc.cluster.local:8080` | NoETL API base                         |
+| `ollama_model`         | `gemma2:2b`                                        | local model for first-pass             |
+| `ollama_mcp_server`    | `mcp/ollama`                                       | catalog path of the Ollama bridge      |
+| `confidence_threshold` | `0.7`                                              | escalate when local confidence < this  |
+| `escalate_to`          | `openai`                                           | `openai` / `claude` / `none`           |
+| `openai_credential`    | `openai_token`                                     | keychain entry for OpenAI API key      |
+| `openai_model`         | `gpt-4o-mini`                                      | OpenAI model for escalation            |
+
+## How callers reach it
+
+Three surfaces:
+
+1. **From a peer playbook**, via `tool: agent framework=noetl`:
+
+   ```yaml
+   - step: diagnose_recent_failure
+     tool:
+       kind: agent
+       framework: noetl
+       entrypoint: automation/agents/troubleshoot/diagnose_execution
+       payload:
+         execution_id: "{{ failed_id }}"
+         confidence_threshold: 0.85
+   ```
+
+2. **Automatically on failure**, via the agent executor's
+   auto-dispatch hook
+   (see [Agent Orchestration → Auto-troubleshoot on failure](./agent_orchestration.md#auto-troubleshoot-on-failure)):
+
+   ```yaml
+   - step: ask_amadeus
+     tool:
+       kind: agent
+       framework: noetl
+       entrypoint: api_integration/amadeus_ai_api
+       on_failure:
+         troubleshoot: true        # diagnosis attaches to error.diagnosis on failure
+   ```
+
+3. **From an external MCP client** (Cursor, Claude Desktop), via the
+   [playbook-as-MCP-server](./playbook_as_mcp_server.md) endpoint:
+
+   ```
+   POST /api/mcp/playbook/automation/agents/troubleshoot/diagnose_execution/jsonrpc
+   ```
+
+## Failure modes the agent classifies
+
+The system prompt asks the model for one of these categories:
+
+| Category         | What it means                                                     |
+|------------------|-------------------------------------------------------------------|
+| `transient_5xx`  | Upstream returned 5xx; usually retryable                          |
+| `auth`           | 401/403; refresh credentials                                      |
+| `rate_limit`     | 429; back off + retry                                             |
+| `bad_request`    | 4xx that's not auth/rate-limit; query needs to change             |
+| `tool_error`     | NoETL tool itself failed (DSL error, missing credential, etc.)    |
+| `infra`          | Worker / database / NATS issue                                    |
+| `unknown`        | Model couldn't classify; signal to escalate                       |
+
+The model is explicitly instructed to be conservative — set
+confidence below 0.5 and category=`unknown` rather than guessing.
+On parse failure (small models occasionally return malformed JSON)
+confidence is forced to 0, which guarantees escalation when the
+operator opted into it.
+
+## What's not in scope
+
+- **Anthropic / Claude escalation.** `escalate_to: claude` is in the
+  schema, the handler is OpenAI-only for now. Trivial to add as a
+  sibling step when needed.
+- **Multi-execution batch diagnosis** ("what broke yesterday?") —
+  separate workflow shape (loop over executions, cluster by
+  category). Out of scope.
+- **The Ollama deployment itself.** This page covers the agent.
+  See [Ollama Bridge](../operations/ollama_bridge.md) for how to
+  stand up the cheap-first inference layer the agent depends on.
+
+## See also
+
+- [Agent Orchestration](./agent_orchestration.md) — the
+  `tool: agent framework=noetl` contract this agent participates in,
+  and the auto-dispatch hook that calls it on failures.
+- [Ollama Bridge](../operations/ollama_bridge.md) — deployment guide
+  for the cheap-first inference layer.
+- [Playbook-as-MCP-Server](./playbook_as_mcp_server.md) — how
+  external MCP clients reach this agent over the wire.

--- a/docs/operations/ollama_bridge.md
+++ b/docs/operations/ollama_bridge.md
@@ -1,0 +1,283 @@
+---
+title: Ollama Bridge — Local Inference for Playbooks
+sidebar_label: Ollama Bridge
+sidebar_position: 6
+---
+
+# Ollama Bridge — Local Inference for Playbooks
+
+The Ollama bridge is a thin MCP-protocol JSON-RPC server that fronts
+a local [Ollama](https://ollama.com) instance, exposing
+`chat` / `generate` / `list_models` as MCP tools. Once registered as
+`mcp/ollama` in the catalog, any playbook can call local Gemma /
+Qwen / Llama models via the standard `tool: kind: mcp` interface.
+
+This is the cheap-first inference layer for the
+[self-troubleshoot agent](../architecture/self_troubleshoot_agent.md):
+playbooks call Ollama for first-pass triage and only escalate to
+OpenAI / Claude when local results are low-confidence.
+
+For the agent contract this bridge participates in, see
+[Agent Orchestration](../architecture/agent_orchestration.md).
+
+## What you end up with
+
+```mermaid
+flowchart LR
+  Worker["noetl-worker"] -->|tool: kind: mcp<br/>server: mcp/ollama| Bridge["ollama_bridge<br/>(sidecar)"]
+  Bridge -->|HTTP /api/chat<br/>/api/generate /api/tags| Ollama["Ollama<br/>(localhost:11434)"]
+  Ollama --> Models["gemma2:2b<br/>qwen2.5:7b<br/>llama3.2"]
+```
+
+Once deployed, a playbook step looks like:
+
+```yaml
+- step: cheap_first_pass
+  tool:
+    kind: mcp
+    server: mcp/ollama
+    tool: chat
+    arguments:
+      model: gemma2:2b
+      system: "You triage NoETL execution failures. Be terse."
+      messages:
+        - role: user
+          content: "{{ failure_summary }}"
+```
+
+## Tools exposed
+
+| Tool          | What it does                                              |
+|---------------|-----------------------------------------------------------|
+| `chat`        | Chat completion (`/api/chat`); OpenAI-compatible messages |
+| `generate`    | Single-prompt completion (`/api/generate`)                |
+| `list_models` | List locally pulled models (`/api/tags`)                  |
+
+The bridge sets `stream: false` on upstream calls and returns the
+fully-assembled response. Streaming would require a different
+transport (SSE or websocket) and the MCP spec for streaming tool
+results is still in flux.
+
+## Tool input schemas
+
+### `chat`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "model": { "type": "string" },
+    "messages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "role": { "type": "string" },
+          "content": { "type": "string" }
+        },
+        "required": ["role", "content"]
+      }
+    },
+    "temperature": { "type": "number", "default": 0.2 },
+    "system": {
+      "type": "string",
+      "description": "Optional system prompt; prepended to messages if provided"
+    }
+  },
+  "required": ["model", "messages"]
+}
+```
+
+The optional `system` field is a convenience: when provided, it's
+prepended to the messages array as a `{role: "system", content: ...}`
+entry. This matches what most callers want without forcing them to
+construct the messages array manually.
+
+### `generate`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "model": { "type": "string" },
+    "prompt": { "type": "string" },
+    "temperature": { "type": "number", "default": 0.2 },
+    "system": { "type": "string" }
+  },
+  "required": ["model", "prompt"]
+}
+```
+
+### `list_models`
+
+No arguments. Returns a newline-separated list of model tags from
+`/api/tags`.
+
+## Response shape
+
+All three tools return the standard MCP content envelope:
+
+```json
+{
+  "content": [{ "type": "text", "text": "<assembled output>" }],
+  "isError": false,
+  "_meta": {
+    "model": "gemma2:2b",
+    "ollama_response": {
+      "total_duration": 1234567,
+      "eval_count": 7,
+      "prompt_eval_count": 12,
+      "done": true
+    }
+  }
+}
+```
+
+The non-standard `_meta` field carries a compact subset of Ollama's
+upstream response (timings, token counts, completion reason) so
+callers can log inference stats without parsing the full body. MCP
+clients that don't recognize `_meta` ignore it.
+
+### Errors
+
+Upstream Ollama failures (model not pulled, server crashed, etc.)
+surface as JSON-RPC error code `-32030` with the upstream URL in
+`error.data.upstream_url`:
+
+```json
+{
+  "jsonrpc": "2.0", "id": 7,
+  "error": {
+    "code": -32030,
+    "message": "ollama /api/chat failed: connection refused",
+    "data": { "upstream_url": "http://broken-ollama/api/chat" }
+  }
+}
+```
+
+This distinguishes "tool returned an error" from "transport failure"
+— useful for callers deciding whether to retry, escalate, or fall
+back.
+
+## Deployment
+
+### Standalone (local dev)
+
+```bash
+# Install Ollama, pull a model
+brew install ollama
+ollama pull gemma2:2b
+ollama serve &
+
+# Run the bridge
+cd /path/to/noetl
+python -m noetl.tools.ollama_bridge
+```
+
+The bridge listens on `0.0.0.0:8765` by default (override with
+`OLLAMA_BRIDGE_PORT`). It points at `http://localhost:11434`
+(override with `OLLAMA_URL`).
+
+### As a sidecar in Kubernetes
+
+The catalog template references a `deployment` block of knobs that
+the noetl Helm chart's `ollamaBridge` section will read once it
+lands. For the spike, deploy the bridge as a separate Deployment +
+Service:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama-bridge
+  namespace: noetl
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: ollama-bridge }
+  template:
+    metadata:
+      labels: { app: ollama-bridge }
+    spec:
+      containers:
+      - name: ollama-bridge
+        image: ghcr.io/noetl/noetl:latest
+        command: ["python", "-m", "noetl.tools.ollama_bridge"]
+        env:
+        - name: OLLAMA_URL
+          value: http://ollama.noetl.svc.cluster.local:11434
+        - name: OLLAMA_BRIDGE_PORT
+          value: "8765"
+        ports:
+        - containerPort: 8765
+        readinessProbe:
+          httpGet: { path: /healthz, port: 8765 }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama-bridge
+  namespace: noetl
+spec:
+  selector: { app: ollama-bridge }
+  ports:
+  - port: 8765
+    targetPort: 8765
+```
+
+Ollama itself is a separate concern — typically a `StatefulSet` with
+a `PersistentVolumeClaim` for the model store, and a NodeSelector
+that pins it to GPU nodes when GPU inference is needed. CPU-only
+inference works fine for 2B-parameter models on commodity nodes.
+
+## Registering with the catalog
+
+The bridge ships with a catalog template at
+`noetl/tools/ollama_bridge/catalog_template.yaml`. Register it once:
+
+```bash
+noetl catalog register --type mcp \
+  /path/to/noetl/noetl/tools/ollama_bridge/catalog_template.yaml
+```
+
+The default `spec.url` points at the in-cluster sidecar service
+(`http://ollama-bridge.noetl.svc.cluster.local:8765/jsonrpc`).
+Override at registration time for non-default deployments —
+the on-disk template is editable.
+
+## Pulling models
+
+The bridge doesn't pre-pull or pre-load models — it assumes the
+operator has run `ollama pull <model>` already. The `list_models`
+tool exposes what's locally available:
+
+```bash
+# Inside the Ollama pod (or your local shell):
+ollama pull gemma2:2b
+ollama pull qwen2.5:7b
+```
+
+`gemma2:2b` is the spike's default — small enough to be fast (~200ms
+on commodity CPU), large enough to handle structured-output prompts.
+For noisier failures or beefier nodes, `qwen2.5:7b` gives better
+classification at ~1s.
+
+## What's not in scope
+
+- **Streaming responses.** Set `stream: false` upstream; assemble +
+  return.
+- **Per-call auth.** Bridge runs on the cluster's private network;
+  expose it with a `NetworkPolicy`, not auth tokens.
+- **Caching.** Ollama is fast enough locally; playbooks have their
+  own retry/cache layers if they need them.
+- **GPU scheduling.** Out of scope for the bridge — that's an
+  Ollama-side concern (NodeSelector, runtime class).
+
+## See also
+
+- [Self-Troubleshoot Agent](../architecture/self_troubleshoot_agent.md)
+  — the worked example that uses this bridge for cheap-first triage.
+- [Agent Orchestration](../architecture/agent_orchestration.md) —
+  how MCP tool calls compose with the agent contract.
+- [MCP Catalog Architecture](../architecture/mcp_catalog_architecture.md)
+  — the higher-level framing for `kind: Mcp` catalog resources.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -27,6 +27,9 @@ const sidebars: SidebarsConfig = {
         'getting-started/semantic-pipeline',
         'architecture/sink_driven_storage',
         'architecture/mcp_catalog_architecture',
+        'architecture/agent_orchestration',
+        'architecture/playbook_as_mcp_server',
+        'architecture/self_troubleshoot_agent',
       ],
     },
     {


### PR DESCRIPTION
docs(architecture): NoETL-as-AI-OS spike pages

Captures the architecture spike (issues #407 / #408 + ops follow-ups)
across four new pages so external readers can navigate from the
high-level `mcp_catalog_architecture` framing down to concrete
deployment + integration steps.

Pages added:

1. **`docs/architecture/agent_orchestration.md`** — reference for the
   `tool: kind: agent` contract. Covers all four frameworks (adk,
   langchain, custom, noetl), the agent envelope, the `framework:
   noetl` short-circuit, and the auto-troubleshoot-on-failure hook
   (Gap 4.1) including the three-way opt-in precedence and
   workload pass-through table.

2. **`docs/architecture/playbook_as_mcp_server.md`** — reference for
   the `POST /api/mcp/playbook/{path}/jsonrpc` endpoint (Gap 2).
   Covers the JSON-RPC protocol surface (initialize / tools/list /
   tools/call / ping), tool-spec derivation from
   `infer_ui_schema` (so MCP schema and GUI workload form stay in
   sync), the `metadata.exposes_as_mcp` opt-out (Gap 3), Cursor /
   Claude Desktop config snippets, and the JSON-RPC error code
   table.

3. **`docs/architecture/self_troubleshoot_agent.md`** — guide for
   the diagnose_execution playbook (Gap 4). Covers the
   cheap-first / escalate flow with a Mermaid diagram, the
   structured diagnosis envelope, all eight workload knobs, the
   three caller surfaces (peer playbook, auto-dispatch, MCP
   client), and the failure category taxonomy the model is
   prompted for.

4. **`docs/operations/ollama_bridge.md`** — operations runbook for
   the `noetl.tools.ollama_bridge` sidecar (Gap 5). Covers the
   three exposed tools (chat / generate / list_models) with
   inputSchemas, the response envelope including the non-standard
   `_meta` field with Ollama timing stats, the JSON-RPC -32030
   upstream-failure error pattern, deployment as standalone (`python
   -m noetl.tools.ollama_bridge`) or as a kubernetes sidecar with
   a Deployment + Service example, registration via
   `noetl catalog register`, and model pulling.

Cross-linking: each page closes with a "See also" block linking to
the other three so readers can navigate the topic from any entry
point. The architecture pages are sibling-positioned (sidebar_position
3-5) right after `mcp_catalog_architecture` (position 2), so the
five MCP-related architecture pages cluster together in the sidebar.

Sidebar wiring: `sidebars.ts` extended with three architecture
entries; the operations page is picked up automatically by the
existing `autogenerated` directive on `docs/operations/`.

What's documented but not yet shipped:

- Helm chart `ollamaBridge` block — the operations page references
  it as "will read once the chart values land". Tracked separately
  in the ai-meta backlog.
- Anthropic / Claude escalation in the troubleshoot agent —
  documented as "schema accepts `escalate_to: claude` but handler is
  OpenAI-only for now". Trivial follow-up.
- Async tool calls / progress notifications on the playbook-as-MCP
  endpoint — documented as "out of scope; tools/call is
  synchronous, 90s ceiling, timeout returns -32011 with
  execution_id".

These are flagged in each page's "What's not in scope" / "What's not
yet" section so readers don't expect features that haven't shipped
yet.

Refs: noetl/noetl#407, noetl/noetl#408, noetl/ops#<TBD>,
      sync/issues/2026-05-03-noetl-as-ai-os-architecture-spike.md.
