### PR TITLE
fix(docs): escape literal '<' in self_troubleshoot_agent so MDX builds

### DIFF
--- a/docs/architecture/self_troubleshoot_agent.md
+++ b/docs/architecture/self_troubleshoot_agent.md
@@ -34,7 +34,7 @@ local model can classify in 200ms.
 
 \* Most failures (HTTP 5xx, transient timeouts, known patterns) stay
 on the Ollama path. Escalation runs only on novel / interesting
-failures — typically <10% in steady state.
+failures — typically `<10%` in steady state.
 
 At fleet error volumes (O(thousands) per day) this is the difference
 between $0/day and ~$30/day in inference spend.


### PR DESCRIPTION
Docusaurus build CI run 25329259643 failed on self_troubleshoot_agent.md:37 — MDX parser interpreted bare `<10%` as a JSX tag start. Wrapped in backticks. Audited the other three new spike pages; all other `<` occurrences are safely inside code fences or inline-code spans.