### PR TITLE
docs: document triage model tradeoffs

### DIFF
--- a/docs/architecture/agent_orchestration.md
+++ b/docs/architecture/agent_orchestration.md
@@ -123,7 +123,7 @@ dominate.
       query: "{{ user_query }}"
     on_failure:
       troubleshoot: true
-      ollama_model: gemma2:2b
+      ollama_model: gemma3:4b
       confidence_threshold: 0.85
       escalate_to: openai
 ```
@@ -219,7 +219,7 @@ release until the projection path is fixed.
 |------------------------|----------------------------------------------------|----------------------------------------|
 | `troubleshoot`         | `false`                                            | per-task opt-in (overrides env)        |
 | `troubleshoot_path`    | `automation/agents/troubleshoot/diagnose_execution`| catalog path of the diagnostic agent   |
-| `ollama_model`         | `gemma2:2b`                                        | local model for first-pass triage      |
+| `ollama_model`         | `gemma3:4b`                                        | local model for first-pass triage      |
 | `ollama_mcp_server`    | `mcp/ollama`                                       | catalog path of the Ollama MCP bridge  |
 | `confidence_threshold` | `0.7`                                              | escalate when local confidence < this  |
 | `escalate_to`          | `openai`                                           | `openai` / `claude` / `none`           |
@@ -305,7 +305,7 @@ tool:
   on_failure:
     troubleshoot: true
     troubleshoot_path: automation/agents/troubleshoot/diagnose_execution
-    ollama_model: gemma2:2b
+    ollama_model: gemma3:4b
     confidence_threshold: 0.7
     escalate_to: openai
 ```
@@ -318,3 +318,6 @@ tool:
   `on_failure.troubleshoot: true` actually invokes.
 - [Ollama Bridge](../operations/ollama_bridge.md) — deploying the
   cheap-first inference layer the troubleshoot agent uses.
+- [Triage Model Selection](./triage_model_selection.md) — how to choose
+  between `gemma3:4b`, `gemma4:e4b`, and escalation models without
+  changing the catalog default.

--- a/docs/architecture/self_troubleshoot_agent.md
+++ b/docs/architecture/self_troubleshoot_agent.md
@@ -90,7 +90,7 @@ auto-dispatch hooks, CI integrations).
 |------------------------|----------------------------------------------------|----------------------------------------|
 | `execution_id`         | `""` (required)                                    | which failed execution to diagnose     |
 | `noetl_url`            | `http://noetl-server.noetl.svc.cluster.local:8080` | NoETL API base                         |
-| `ollama_model`         | `gemma2:2b`                                        | local model for first-pass             |
+| `ollama_model`         | `gemma3:4b`                                        | local model for first-pass             |
 | `ollama_mcp_server`    | `mcp/ollama`                                       | catalog path of the Ollama bridge      |
 | `confidence_threshold` | `0.7`                                              | escalate when local confidence < this  |
 | `escalate_to`          | `openai`                                           | `openai` / `claude` / `none`           |
@@ -195,5 +195,7 @@ upstream availability.
   and the auto-dispatch hook that calls it on failures.
 - [Ollama Bridge](../operations/ollama_bridge.md) — deployment guide
   for the cheap-first inference layer.
+- [Triage Model Selection](./triage_model_selection.md) — model sizing,
+  overrides, and escalation tradeoffs for the diagnosis path.
 - [Playbook-as-MCP-Server](./playbook_as_mcp_server.md) — how
   external MCP clients reach this agent over the wire.

--- a/docs/architecture/triage_model_selection.md
+++ b/docs/architecture/triage_model_selection.md
@@ -1,0 +1,166 @@
+---
+id: triage_model_selection
+title: Triage Model Selection
+sidebar_label: Triage Model Selection
+sidebar_position: 6
+---
+
+# Triage Model Selection
+
+NoETL's self-troubleshoot path uses a local Ollama model first and
+escalates only when confidence is too low. Keep those two choices
+separate:
+
+- the **default triage model** is the model used for the first local
+  diagnosis attempt;
+- the **escalation tier** is invoked only when the first-pass diagnosis
+  is not confident enough and the workload allows escalation.
+
+## Default: `gemma3:4b`
+
+`gemma3:4b` is the default first-pass model for the troubleshoot agent.
+It is the right default for local kind clusters, developer laptops, and
+memory-constrained worker nodes because it fits in roughly 4 GiB total
+memory while still producing reliable structured JSON for known failure
+patterns.
+
+```bash
+ollama pull gemma3:4b
+```
+
+Use the [Gemma 3 Ollama library page](https://ollama.com/library/gemma3)
+and select the `4b` tag. This is the model validated across the
+NoETL-as-AI-OS evidence trail from v2.35.3 through v2.35.9. The spike
+e2e workflow, auto-troubleshoot smoke, optional-AI smoke, and
+live-vs-persisted parity smoke all assume this remains safe for
+commodity local clusters.
+
+Do not replace the catalog default just because a larger model is
+available. The default needs to run where NoETL itself is being
+developed and debugged.
+
+## Higher-quality opt-in: `gemma4:e4b`
+
+`gemma4:e4b` is a higher-quality local model for production
+deployments with dedicated memory for Ollama. It is an opt-in workload
+override, not the catalog default.
+
+```bash
+ollama pull gemma4:e4b
+```
+
+See the [Gemma 4 e4b Ollama library page](https://ollama.com/library/gemma4:e4b).
+
+Memory profile measured on 2026-05-06:
+
+| Measurement | Value |
+|---|---:|
+| Resident model after pull/load | ~9.4 GiB |
+| Additional inference working set | ~9.8 GiB |
+| Practical cgroup requirement | ~20 GiB |
+| Local kind-on-Podman VM floor | ~24 GiB |
+
+The validation attempt that produced this measurement ran on a
+16 GiB Podman VM with the Ollama pod temporarily raised to a 12 GiB
+cgroup limit. The model loaded, but inference failed:
+
+```text
+model requires more system memory (9.8 GiB) than is available (3.3 GiB)
+```
+
+That message is easy to misread. Ollama is reporting the **additional**
+memory the inference pass needs on top of the already-loaded model, not
+the total memory needed for the model. If you see "needs 9.8 GiB
+available" while the model is already resident in a 12 GiB cgroup, you
+do not need 12 GiB total; you need roughly 20 GiB of room for the
+resident model plus the inference working set.
+
+Use `gemma4:e4b` for production clusters with a dedicated Ollama node
+or pod budget. Good fits include GKE node pools with at least 24 GiB
+allocated to Ollama, EKS `m6i.2xlarge`-class nodes or larger, or
+self-managed clusters with dedicated AI nodes.
+
+Workloads opt in by passing `ollama_model: "gemma4:e4b"`:
+
+```bash
+noetl exec tests/spike/spike_e2e_test \
+  --runtime distributed \
+  --payload '{"escalate_to":"none","ollama_model":"gemma4:e4b"}'
+```
+
+Leave the catalog default as `gemma3:4b`; larger-model use should be
+intentional per workload or per environment.
+
+## Escalation tier: `qwen3:32b`
+
+`qwen3:32b` is the local heavyweight tier for cases where the first
+model returns low confidence and the workload allows escalation. It is
+roughly a 19 GiB model, so it belongs on production-grade Ollama nodes,
+not small local clusters.
+
+This is a different axis from choosing the default model:
+
+- default-model choice decides which model tries first;
+- escalation decides what happens when that first answer is not
+  confident enough.
+
+The troubleshoot agent escalates when:
+
+1. the parsed local diagnosis has `confidence < confidence_threshold`;
+2. `escalate_to` allows a second pass, such as `ollama`, `openai`, or
+   `claude`;
+3. the required model or credential is available.
+
+If escalation is disabled with `escalate_to: "none"`, the agent returns
+the local diagnosis even when confidence is low.
+
+## How the choice flows
+
+```mermaid
+flowchart LR
+  catalog["Catalog default<br/>diagnose_execution.yaml<br/>ollama_model: gemma3:4b"]
+  workload["Workload override<br/>payload.ollama_model"]
+  local["Local Ollama triage"]
+  confidence{"confidence<br/>&lt; threshold?"}
+  disabled["Return local diagnosis"]
+  escalation["Escalation tier<br/>qwen3:32b / OpenAI / Claude"]
+  result["Structured diagnosis"]
+
+  catalog --> workload --> local --> confidence
+  confidence -- "no" --> result
+  confidence -- "yes, escalation disabled" --> disabled --> result
+  confidence -- "yes, escalation allowed" --> escalation --> result
+```
+
+Worked example:
+
+```json
+{
+  "escalate_to": "none",
+  "ollama_model": "gemma4:e4b"
+}
+```
+
+This payload asks the spike e2e workflow to use `gemma4:e4b` for the
+local diagnosis only. Because `escalate_to` is `none`, a low-confidence
+answer still returns from the local model and does not call the
+escalation tier.
+
+## Operational notes
+
+- The default Ollama pod budget was raised after ops#38 because 4 GiB
+  was too small for reliable `gemma3:4b` inference. The local default is
+  now a 3 GiB request and 5 GiB limit.
+- Local kind development uses Podman only. The Podman machine must mount
+  the shared checkout path, including `/Volumes:/Volumes` on macOS, so
+  kind can read manifests and local automation paths.
+- Run Podman and kind commands with `XDG_DATA_HOME` unset when the
+  machine was created that way; otherwise the CLI can look at the wrong
+  machine metadata.
+- Do not use Colima for the NoETL local kind workflow. Keep the
+  Podman-backed `kind-noetl` path deterministic.
+- The 2026-05-06 `gemma4:e4b` validation result is recorded in
+  `bridge/outbox/20260506-025752-option-b-gemma4-evidence-doc-coverage.result.json`
+  in the `ai-meta` repository. Treat its cgroup math as the current
+  sizing floor until a larger local VM or production node proves a new
+  lower bound.

--- a/docs/operations/ollama_bridge.md
+++ b/docs/operations/ollama_bridge.md
@@ -26,7 +26,7 @@ For the agent contract this bridge participates in, see
 flowchart LR
   Worker["noetl-worker"] -->|tool: kind: mcp<br/>server: mcp/ollama| Bridge["ollama_bridge<br/>(sidecar)"]
   Bridge -->|HTTP /api/chat<br/>/api/generate /api/tags| Ollama["Ollama<br/>(localhost:11434)"]
-  Ollama --> Models["gemma2:2b<br/>qwen2.5:7b<br/>llama3.2"]
+  Ollama --> Models["gemma3:4b<br/>gemma4:e4b<br/>qwen3:32b"]
 ```
 
 Once deployed, a playbook step looks like:
@@ -38,7 +38,7 @@ Once deployed, a playbook step looks like:
     server: mcp/ollama
     tool: chat
     arguments:
-      model: gemma2:2b
+      model: gemma3:4b
       system: "You triage NoETL execution failures. Be terse."
       messages:
         - role: user
@@ -122,7 +122,7 @@ All three tools return the standard MCP content envelope:
   "content": [{ "type": "text", "text": "<assembled output>" }],
   "isError": false,
   "_meta": {
-    "model": "gemma2:2b",
+    "model": "gemma3:4b",
     "ollama_response": {
       "total_duration": 1234567,
       "eval_count": 7,
@@ -166,7 +166,7 @@ back.
 ```bash
 # Install Ollama, pull a model
 brew install ollama
-ollama pull gemma2:2b
+ollama pull gemma3:4b
 ollama serve &
 
 # Run the bridge
@@ -309,14 +309,16 @@ tool exposes what's locally available:
 
 ```bash
 # Inside the Ollama pod (or your local shell):
-ollama pull gemma2:2b
-ollama pull qwen2.5:7b
+ollama pull gemma3:4b
+ollama pull qwen3:32b
 ```
 
-`gemma2:2b` is the spike's default — small enough to be fast (~200ms
-on commodity CPU), large enough to handle structured-output prompts.
-For noisier failures or beefier nodes, `qwen2.5:7b` gives better
-classification at ~1s.
+`gemma3:4b` is the spike's default because it fits in small local
+clusters while still handling structured-output prompts. For production
+nodes with a dedicated Ollama budget, workloads can opt into
+`gemma4:e4b`; for confidence-driven escalation, use `qwen3:32b`.
+See [Triage Model Selection](../architecture/triage_model_selection.md)
+for the sizing tradeoffs and the measured cgroup memory requirements.
 
 ## What's not in scope
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -30,6 +30,7 @@ const sidebars: SidebarsConfig = {
         'architecture/agent_orchestration',
         'architecture/playbook_as_mcp_server',
         'architecture/self_troubleshoot_agent',
+        'architecture/triage_model_selection',
       ],
     },
     {


### PR DESCRIPTION
Docs-only follow-up for task 20260506-032648 and prior RED result bridge/outbox/20260506-025752-option-b-gemma4-evidence-doc-coverage.result.json.

This adds a triage model selection page covering:
- gemma3:4b as the default for dev and memory-constrained clusters
- gemma4:e4b as a higher-quality opt-in with the measured 2026-05-06 cgroup math
- qwen3:32b as the confidence-driven escalation tier
- the flow from catalog default to workload override to escalation

Also updates stale gemma2/qwen2.5 examples in the agent and Ollama bridge docs.

Validation:
- npm run build
  - Build succeeded.
  - Docusaurus still reports two pre-existing broken anchors unrelated to this PR.