### PR TITLE
docs: operational reference for bump_image lifecycle and local Podman/kind setup

### DIFF
--- a/docs/architecture/mcp_catalog_architecture.md
+++ b/docs/architecture/mcp_catalog_architecture.md
@@ -234,6 +234,8 @@ mcp/kubernetes :: Read-only Kubernetes runtime agent backed by the Kubernetes MC
 ...
 ```
 
+### Metadata fields
+
 Each button opens a **friendly run dialog** generated from
 `/api/catalog/{path}/ui_schema`. The endpoint walks the
 playbook's `workload:` block and emits a JSON-Schema-shaped

--- a/docs/operations/bump_image.md
+++ b/docs/operations/bump_image.md
@@ -1,0 +1,125 @@
+---
+title: bump_image Lifecycle
+sidebar_label: bump_image Lifecycle
+sidebar_position: 7
+---
+
+# bump_image Lifecycle
+
+`noetl/lifecycle/bump_image` is the operational playbook used to move a
+running NoETL cluster to a specific container image tag. It is the
+preferred path for local validation and release smoke tests because it
+keeps the update logic in catalog-registered automation instead of
+scattering ad hoc `kubectl set image` commands across runbooks.
+
+## What it does
+
+The playbook updates the NoETL runtime deployments in the `noetl`
+namespace:
+
+- `noetl-server`
+- `noetl-worker`
+- `ollama-bridge`
+
+For each selected deployment, the playbook:
+
+1. resolves the target image from the workload;
+2. probes external GHCR images before touching the cluster;
+3. checks whether the running deployment already uses the image;
+4. runs `kubectl set image` when an update is needed;
+5. waits with `kubectl rollout status`;
+6. reports the per-component result as structured output.
+
+The implementation is POSIX-shell safe. It does not depend on bash-only
+features such as associative arrays, which keeps it portable across the
+minimal shells used by worker images and local operator environments.
+
+## GHCR availability probe
+
+The GHCR probe added in
+[ops#37](https://github.com/noetl/ops/pull/37) protects the release
+validation path from a common race: GitHub can publish a release tag
+before the corresponding `ghcr.io/noetl/noetl:<tag>` manifest is
+available to pull.
+
+Before the rollout loop starts, the playbook sends a `HEAD` request to:
+
+```text
+https://ghcr.io/v2/noetl/noetl/manifests/<tag>
+```
+
+It retries until the manifest is visible or the attempt budget is
+exhausted. On the final failed attempt, the playbook returns a clear
+structured error and exits before changing any deployment.
+
+Workload knobs:
+
+| Knob | Default behavior |
+|---|---|
+| `ghcr_probe_attempts` | Maximum number of manifest probes. |
+| `ghcr_probe_sleep_seconds` | Sleep interval between probes. |
+
+The probe runs only for known external registry image names, such as
+`ghcr.io/noetl/noetl:v2.35.9`. Local development images and kind/Podman
+shortcuts are skipped because there is no remote manifest to check.
+
+## Idempotent unchanged path
+
+If the target deployment already uses the requested image, the playbook
+returns an unchanged result for that component instead of forcing a
+rollout. This is useful for validation loops:
+
+- rerunning the playbook after a successful deploy should be clean;
+- release validation can prove the "already deployed" path without
+  restarting pods;
+- a partially updated cluster reports exactly which components changed
+  and which were already current.
+
+## Failure modes
+
+| Symptom | Meaning | Operator response |
+|---|---|---|
+| GHCR probe fails | The release image is not available yet or the node cannot reach GHCR. | Wait for the package to publish, verify package visibility, or fix network/DNS. |
+| Rollout timeout | Kubernetes accepted the image update but the deployment did not become ready. | Inspect `kubectl -n noetl describe pod` and deployment events. |
+| Per-component error | One deployment failed while another succeeded or was unchanged. | Fix the failed component, then rerun the same payload. |
+| Local image skipped probe but pull fails | The image name looked local, so no remote check was possible. | Confirm the image exists in the kind node runtime. |
+
+## Worked example
+
+Deploy a released NoETL tag to all default runtime components:
+
+```bash
+noetl exec noetl/lifecycle/bump_image \
+  --runtime distributed \
+  --payload '{
+    "namespace": "noetl",
+    "image": "ghcr.io/noetl/noetl:v2.35.9"
+  }'
+```
+
+Expected shape:
+
+```text
+noetl-server  changed|unchanged  ghcr.io/noetl/noetl:v2.35.9
+noetl-worker  changed|unchanged  ghcr.io/noetl/noetl:v2.35.9
+ollama-bridge changed|unchanged  ghcr.io/noetl/noetl:v2.35.9
+```
+
+Target one component explicitly when only a single deployment needs to
+move:
+
+```bash
+noetl exec noetl/lifecycle/bump_image \
+  --runtime distributed \
+  --payload '{
+    "deployment": "noetl-worker",
+    "namespace": "noetl",
+    "image": "ghcr.io/noetl/noetl:v2.35.9",
+    "ghcr_probe_attempts": 12,
+    "ghcr_probe_sleep_seconds": 10
+  }'
+```
+
+Use the same playbook for release validation and local recovery. Reach
+for raw `kubectl set image` only when the catalog or worker path itself
+is the part being repaired.

--- a/docs/operations/local-cluster.md
+++ b/docs/operations/local-cluster.md
@@ -1,0 +1,122 @@
+---
+title: Local Podman Kind Cluster
+sidebar_label: Local Podman Kind Cluster
+sidebar_position: 8
+---
+
+# Local Podman Kind Cluster
+
+NoETL local development uses a Podman-backed kind cluster. Do not use
+Docker Desktop or Colima for the canonical local path. Keeping one
+container runtime removes a whole class of "wrong node runtime" and
+volume-mount drift when testing playbooks, worker images, GUI images,
+and Ollama-backed diagnostics.
+
+## Why Podman, not Docker or Colima
+
+The NoETL local automation assumes:
+
+- kind nodes run on the Podman machine;
+- local source paths under `/Volumes` can be mounted into the kind node;
+- the same runtime is used when loading or pulling images for local
+  validation;
+- operator commands can be repeated without switching Docker contexts.
+
+Colima is intentionally out of scope for this workflow. If it appears in
+a local note or terminal history, treat it as stale. Use Podman only for
+the `kind-noetl` cluster.
+
+## Required `/Volumes` mount
+
+On macOS, the shared checkout lives under `/Volumes/X10/...`. The
+Podman machine must expose `/Volumes:/Volumes`; otherwise kind
+`extraMounts` and local automation paths cannot resolve files inside
+the node.
+
+When creating or recreating the machine, make sure the shared mount is
+present before creating the kind cluster. A missing mount is usually
+visible as Kubernetes pods failing to find manifests, generated files,
+or local playbook paths that exist on the host.
+
+## `XDG_DATA_HOME` hygiene
+
+Run Podman and kind commands with `XDG_DATA_HOME` unset unless the
+machine was explicitly created with that variable set:
+
+```bash
+unset XDG_DATA_HOME
+podman machine list
+kind get clusters
+```
+
+Podman stores machine metadata under the data home. Mixing values can
+make the CLI look at a different machine than the one kind is using.
+
+## Sizing
+
+A practical local baseline is:
+
+| Resource | Recommended local baseline |
+|---|---:|
+| CPU | 4 |
+| Memory | 16 GiB |
+| Disk | 200 GiB |
+
+This is enough for the default NoETL stack and `gemma3:4b` diagnostics.
+It is not enough to run `gemma4:e4b` inference inside the default
+Ollama cgroup. The measured `gemma4:e4b` profile is about 9.4 GiB for
+the resident model plus another 9.8 GiB for the inference working set,
+or roughly 20 GiB total for the pod cgroup. See
+[Triage Model Selection](../architecture/triage_model_selection.md) for
+the model tradeoff details.
+
+Keep `gemma3:4b` as the local default. Treat `gemma4:e4b` as a
+production or large-node opt-in.
+
+## Optional persistence
+
+Some operators use a macOS LaunchAgent to keep the Podman machine
+started after reboots. The local convention is a
+`com.noetl.podman-machine.plist` style LaunchAgent, but the repository
+does not require a specific plist. If you use one, keep it local to the
+machine and do not commit user-specific paths or secrets.
+
+## Bootstrap and recovery commands
+
+Inspect the Podman machine:
+
+```bash
+unset XDG_DATA_HOME
+podman machine list
+podman machine inspect
+```
+
+Start or stop it:
+
+```bash
+unset XDG_DATA_HOME
+podman machine start
+podman machine stop
+```
+
+Create the kind cluster from the ops repo:
+
+```bash
+cd /Volumes/X10/projects/noetl/ai-meta/repos/ops
+kind create cluster --config=ci/kind/config.yaml
+kubectl config use-context kind-noetl
+kubectl cluster-info
+```
+
+Delete and recreate only when the user has explicitly chosen that path:
+
+```bash
+unset XDG_DATA_HOME
+kind delete cluster --name noetl
+kind create cluster --config=ci/kind/config.yaml
+kubectl config use-context kind-noetl
+```
+
+After cluster recreation, deploy NoETL through the ops playbooks or the
+documented release deployment path. Avoid one-off scripts unless the
+automation being repaired is itself unavailable.

--- a/docs/reference/recreate-noetl-schema.md
+++ b/docs/reference/recreate-noetl-schema.md
@@ -25,5 +25,5 @@ PGPASSWORD=demo bin/noetl run automation/setup/rebuild_schema.yaml
 - Playbook path: `automation/setup/rebuild_schema.yaml`
 
 ## Related Topics
-- [Database Management](./noetl_cli_usage#database-management)
+- [Database Management](../cli/usage.md#database-management)
 - [Local Development Setup](../development/local_dev_setup)


### PR DESCRIPTION
## Summary
- add operations docs for the bump_image lifecycle, including the GHCR manifest probe, idempotent unchanged path, failure modes, and worked examples
- add local Podman/kind cluster operations guidance with the /Volumes mount, XDG_DATA_HOME hygiene, sizing, and recovery commands
- fix the two Docusaurus anchor warnings observed in the docs build

## Validation
- npm install
- npm run build