### PR TITLE
docs: reconcile Vertex model defaults to gemini-2.5-flash + add Model Availability troubleshooting

### DIFF
--- a/docs/architecture/triage_model_selection.md
+++ b/docs/architecture/triage_model_selection.md
@@ -120,7 +120,11 @@ For GKE deployments that use a cloud-managed backend instead of
 in-cluster Ollama, see
 [Vertex AI Triage Backend](./vertex_ai_triage_backend.md). That page
 documents the MCP pointer-swap contract and the `triage_mcp_server` /
-`triage_model` workload names.
+`triage_model` workload names. The validated GKE production analogue
+for the default tier is `gemini-2.5-flash`; see the
+[Model availability and the 404 troubleshooting note](./vertex_ai_triage_backend.md#model-availability-and-the-404-troubleshooting-note)
+for why earlier `gemini-2.0-flash` examples hit 404 and were retired for this
+project.
 
 ```mermaid
 flowchart LR

--- a/docs/architecture/vertex_ai_triage_backend.md
+++ b/docs/architecture/vertex_ai_triage_backend.md
@@ -55,7 +55,7 @@ over HTTP:
   "params": {
     "name": "chat_completion",
     "arguments": {
-      "model": "gemini-2.0-flash",
+      "model": "gemini-2.5-flash",
       "temperature": 0.1,
       "messages": [
         {"role": "user", "content": "{\"execution_id\":\"...\"}"}
@@ -85,7 +85,7 @@ diagnosis fields consumed by `diagnose_execution`:
     "isError": false,
     "_meta": {
       "backend": "vertex-ai-stub",
-      "model": "gemini-2.0-flash",
+      "model": "gemini-2.5-flash",
       "usage": {
         "prompt_tokens": 1234,
         "completion_tokens": 256,
@@ -144,13 +144,45 @@ backend owns provider-specific validation and mapping.
 
 | Local tier | Cloud analogue | Use |
 |---|---|---|
-| `gemma3:4b` | `gemini-2.0-flash` | Default triage tier. Fast, low-cost, suitable for common failures. |
-| `gemma4:e4b` | `gemini-2.0-flash-thinking` | Higher-quality opt-in tier for deeper local or cloud reasoning. |
+| `gemma3:4b` | `gemini-2.5-flash` | Default triage tier. Fast, low-cost, suitable for common failures. |
+| `gemma4:e4b` | `gemini-2.5-flash` | Higher-quality opt-in in this project until a separately approved thinking-capable Vertex model is enabled. |
 | `qwen3:32b` | `gemini-2.5-pro` | Escalation tier for low-confidence diagnoses. |
 
 `gemini-2.0-pro` is also a valid operator choice where that SKU is the
 approved escalation model for a deployment. The NoETL diagnose path
 does not rewrite model names; operators pin the cloud model they want.
+
+## Model availability and the 404 troubleshooting note
+
+During the 2026-05-06 GKE validation for project
+`noetl-demo-19700101`, `gemini-2.0-flash` returned Vertex AI HTTP 404,
+and `gemini-2.0-flash-001` returned Vertex AI HTTP 404, across both
+`us-central1` and `global` endpoint tests. The same Workload Identity
+path succeeded with `gemini-2.5-flash`; execution
+`620639495284589035` is the validation proof for the working
+`mcp/vertex-ai` pointer swap.
+
+Treat a model 404 as an operator-side availability check, not a NoETL
+runtime failure. Common causes include:
+
+- Vertex AI Model Garden activation or access being project-specific.
+- Region availability differences between `us-central1`, `global`, and
+  other Vertex AI locations.
+- Project tier or billing restrictions that limit which publisher
+  models are available.
+- Model lifecycle changes as newer Gemini versions supersede older
+  model names.
+
+Operators can enumerate project-visible models with:
+
+```bash
+gcloud ai models list --region=us-central1 --project=<project-id>
+```
+
+The Vertex AI Model Garden console gives the same availability view
+with governance and cost context. NoETL does not recommend activating a
+specific model automatically; the model choice is a deployment
+decision.
 
 ## Credential Surface Unification
 
@@ -226,7 +258,7 @@ An operator on a v2.35.9-style cluster can move gradually:
    ```json
    {
      "triage_mcp_server": "mcp/vertex-ai",
-     "triage_model": "gemini-2.0-flash",
+     "triage_model": "gemini-2.5-flash",
      "escalate_to": "none"
    }
    ```


### PR DESCRIPTION
Reconciles the Vertex AI triage documentation to the empirically available production default for noetl-demo-19700101: gemini-2.5-flash.\n\nChanges:\n- Updates production-default payloads, examples, and mapping tables from gemini-2.0-flash to gemini-2.5-flash.\n- Preserves gemini-2.0-flash references only inside the new 404 troubleshooting note.\n- Adds a Model availability troubleshooting section with the prior GKE execution evidence and operator-side diagnostic guidance.\n- Cross-links triage model selection to the Vertex availability note.\n\nValidation:\n- npm run build