### PR TITLE
docs: document cloud-vs-local latency variance for diagnosis_lookup.attempts

### DIFF
--- a/docs/architecture/agent_failure_diagnostics.md
+++ b/docs/architecture/agent_failure_diagnostics.md
@@ -177,6 +177,12 @@ The successful assertion proves all of these at once:
 - the persisted execution API preserved the nested diagnosis;
 - the report can be consumed by the GUI, CLI, and bridge tasks.
 
+When reading `diagnosis_lookup.attempts`, use the backend-specific
+latency profile. Local Ollama should normally stay at `0` and only
+occasionally hit `1`; cloud backends such as Vertex AI can normally
+range from `0` to `3`, with up to about `5` acceptable on slow
+networks.
+
 Run it from `ai-meta`:
 
 ```bash

--- a/docs/architecture/triage_model_selection.md
+++ b/docs/architecture/triage_model_selection.md
@@ -35,6 +35,10 @@ e2e workflow, auto-troubleshoot smoke, optional-AI smoke, and
 live-vs-persisted parity smoke all assume this remains safe for
 commodity local clusters.
 
+For this local backend, `diagnosis_lookup.attempts == 0` is typical,
+`1` is an occasional timing race, and anything above `1` should be
+treated as a regression signal.
+
 Do not replace the catalog default just because a larger model is
 available. The default needs to run where NoETL itself is being
 developed and debugged.
@@ -80,6 +84,11 @@ or pod budget. Good fits include GKE node pools with at least 24 GiB
 allocated to Ollama, EKS `m6i.2xlarge`-class nodes or larger, or
 self-managed clusters with dedicated AI nodes.
 
+Because this is still an in-cluster local backend, its persisted
+diagnosis should usually arrive within `0` to `1`
+`diagnosis_lookup.attempts`; sustained values above `1` deserve
+investigation.
+
 Workloads opt in by passing `ollama_model: "gemma4:e4b"`:
 
 ```bash
@@ -114,6 +123,12 @@ The troubleshoot agent escalates when:
 If escalation is disabled with `escalate_to: "none"`, the agent returns
 the local diagnosis even when confidence is low.
 
+Escalation calls can be slower than the local default. Cloud escalation
+backends should be interpreted with the same latency profile documented
+for Vertex AI: `0` to `3` `diagnosis_lookup.attempts` is normal, up to
+about `5` can be acceptable on a slow network, and sustained values
+above `5` should be investigated.
+
 ## How the choice flows
 
 For GKE deployments that use a cloud-managed backend instead of
@@ -125,6 +140,12 @@ for the default tier is `gemini-2.5-flash`; see the
 [Model availability and the 404 troubleshooting note](./vertex_ai_triage_backend.md#model-availability-and-the-404-troubleshooting-note)
 for why earlier `gemini-2.0-flash` examples hit 404 and were retired for this
 project.
+
+When that backend is `mcp/vertex-ai`, the expected polling profile is
+wider than local Ollama: `0` to `3` `diagnosis_lookup.attempts` is
+normal and up to about `5` can be acceptable on slow networks. See
+[Cloud latency vs local](./vertex_ai_triage_backend.md#cloud-latency-vs-local----what-to-expect-from-diagnosis_lookupattempts)
+for the measured GKE evidence.
 
 ```mermaid
 flowchart LR

--- a/docs/architecture/vertex_ai_triage_backend.md
+++ b/docs/architecture/vertex_ai_triage_backend.md
@@ -184,6 +184,42 @@ with governance and cost context. NoETL does not recommend activating a
 specific model automatically; the model choice is a deployment
 decision.
 
+## Cloud latency vs local -- what to expect from `diagnosis_lookup.attempts`
+
+`diagnosis_lookup.attempts` is a regression detector, but its normal
+range depends on the triage backend.
+
+For **local Ollama** backends such as `mcp/ollama` with `gemma3:4b`,
+inference usually takes about 200-500 ms inside the cluster. The
+persisted-diagnosis event normally flushes before the NoETL-side retry
+budget is exhausted. Expect `attempts == 0` in the common case and
+`attempts == 1` occasionally when the noetl#416 retry race catches the
+event just after the first read. Anything above `1` on the local path
+is a regression signal.
+
+For **cloud Vertex AI** backends such as `mcp/vertex-ai` with
+`gemini-2.5-flash`, inference includes a network round trip plus
+Google's processing time and commonly lands in the 1-3s+ range. Expect
+`attempts == 0` through `attempts == 3` as normal operational variance.
+Attempts up to about `5` can be acceptable on a slow network; sustained
+values above `5` are worth investigating.
+
+The 2026-05-06 GKE six-run sweep measured this directly: all six spike
+runs completed with `source=vertex-ai` and `model=gemini-2.5-flash`;
+four of six runs had `diagnosis_lookup.attempts <= 1`; two runs needed
+two to three attempts, specifically executions `620875219263030195`
+and `620877265538122480`.
+
+This happens because the spike fixture has a belt-and-suspenders
+polling loop after the NoETL-side
+`_fetch_persisted_diagnosis_from_doc` retry budget. That retry budget
+was tuned against Ollama timing in v2.35.5 via noetl#416. Cloud
+backends can legitimately need the fixture poll to bridge the extra
+latency until the retry budget is made cloud-aware.
+
+The planned follow-up is captured in the `ai-meta` sync issue
+`sync/issues/2026-05-06-noetl-retry-budget-cloud-aware.md`.
+
 ## Credential Surface Unification
 
 Each MCP backend playbook encapsulates its own credential pattern:


### PR DESCRIPTION
Documents the measured cloud-vs-local latency difference for auto-troubleshoot diagnosis lookup.\n\nChanges:\n- Adds backend-specific diagnosis_lookup.attempts expectations to triage model selection.\n- Adds a Vertex AI section explaining local Ollama vs cloud Vertex latency and the 2026-05-06 six-run evidence.\n- Notes the backend-specific interpretation in the agent failure diagnostics spike workflow.\n\nValidation:\n- npm run build