### PR TITLE
docs(tutorials): use noetl status, not raw curl

### DIFF
--- a/docs/tutorials/01-quickstart.md
+++ b/docs/tutorials/01-quickstart.md
@@ -137,8 +137,14 @@ echo "execution: $EXEC_ID"
 
 # Wait for terminal status — typically 8–15 seconds on local kind.
 sleep 30
-curl -sf "http://localhost:8082/api/executions/$EXEC_ID" > /tmp/spike.json
+noetl status "$EXEC_ID" --json > /tmp/spike.json
 ```
+
+`noetl status` is the canonical way to fetch execution state. It hits the
+same `/api/executions/<id>` endpoint the gateway exposes but goes through
+the CLI's host/port resolution and credential plumbing — keeps your scripts
+portable across local kind, GKE, and any future deployment topology
+without hardcoded URLs.
 
 Run the assertion script to confirm GREEN:
 

--- a/docs/tutorials/03-self-troubleshooting-playbook.md
+++ b/docs/tutorials/03-self-troubleshooting-playbook.md
@@ -195,8 +195,14 @@ echo "execution: $EXEC_ID"
 
 # Wait for terminal — typically 5–10 seconds with warm gemma3:4b.
 sleep 15
-curl -sf "http://localhost:8082/api/executions/$EXEC_ID" > /tmp/canary.json
+noetl status "$EXEC_ID" --json > /tmp/canary.json
 ```
+
+Always go through `noetl status` rather than raw `curl` against
+`/api/executions/<id>`. The CLI handles host/port resolution, gateway
+auth, and JSON shape conventions consistently across local kind, GKE, and
+any future deployment topology — your tutorials and runbooks stay portable
+without hardcoded URLs.
 
 Pull the parent's terminal result:
 


### PR DESCRIPTION
Both quickstart and self-troubleshooting tutorials had raw `curl` against `/api/executions/$EXEC_ID` to fetch terminal state. Replaced with `noetl status $EXEC_ID --json` so the same tutorial commands work portably across deployment topologies.