### PR TITLE
fix(docs): MDX-style comments in stub tutorials

### DIFF
--- a/docs/tutorials/02-gke-production-deploy.md
+++ b/docs/tutorials/02-gke-production-deploy.md
@@ -23,7 +23,7 @@ Estimated time: 1–2 hours including provisioning.
 
 ## Prerequisites
 
-<!-- TODO: enumerate concretely -->
+{/* TODO: enumerate concretely */}
 - Completed [Quickstart](./01-quickstart.md) so you understand the
   local-cluster baseline.
 - A GCP project with billing enabled and the following APIs on:
@@ -38,20 +38,20 @@ Estimated time: 1–2 hours including provisioning.
 
 ## Step 1 — Provision the cluster
 
-<!-- TODO:
+{/* TODO:
   - Run noetl_gke_fresh_stack with action=provision-deploy
   - Pick autopilot vs standard based on workload sizing
   - The blueprint at automation/gcp_gke/blueprints/noetl-cluster-blueprint.json
     is the source of truth for cluster shape
   - Cite operations/gcp/gke-cloudsql-end-to-end.md for the long-form variant
   - Walk the actual command + expected output
--->
+*/}
 
 Reference: [`automation/gcp_gke/noetl_gke_fresh_stack.yaml`](https://github.com/noetl/ops/blob/main/automation/gcp_gke/noetl_gke_fresh_stack.yaml).
 
 ## Step 2 — Wire Workload Identity for Vertex AI
 
-<!-- TODO:
+{/* TODO:
   - Create GCP service account, bind roles/aiplatform.user
   - Create k8s service account, annotate with Workload Identity binding
   - Patch noetl-worker deployment to use the bound k8s SA
@@ -59,7 +59,7 @@ Reference: [`automation/gcp_gke/noetl_gke_fresh_stack.yaml`](https://github.com/
     cloud-platform scope token can be retrieved
   - Cite architecture/vertex_ai_triage_backend.md for the credential
     surface design
--->
+*/}
 
 The token flow goes through the GKE metadata server with the
 `https://www.googleapis.com/auth/cloud-platform` scope. See
@@ -68,7 +68,7 @@ for why this is preferred over service-account JSON files in pods.
 
 ## Step 3 — Configure Auth0 callbacks
 
-<!-- TODO:
+{/* TODO:
   - Add callback URLs: https://<your-gateway-host>/callback,
     https://<your-gateway-host>/api/auth/callback
   - Add allowed origins
@@ -76,11 +76,11 @@ for why this is preferred over service-account JSON files in pods.
   - Wire gateway deployment to read those secrets via External Secrets
     Operator or CSI Secret Store driver
   - Cite gateway/auth-integration.md and gateway/auth0-setup.md
--->
+*/}
 
 ## Step 4 — Deploy via `bump_image` lifecycle
 
-<!-- TODO:
+{/* TODO:
   - Use noetl exec automation/agents/noetl/lifecycle/bump_image
     payloads for noetl-server, noetl-worker, ollama-bridge OR skip
     ollama-bridge if you're going pure-Vertex with no in-cluster
@@ -88,24 +88,24 @@ for why this is preferred over service-account JSON files in pods.
   - The GHCR availability probe from ops#37 catches release races
     automatically — see operations/bump_image.md
   - Wait for kubectl rollout status on each
--->
+*/}
 
 Reference: [Bump Image Lifecycle](../operations/bump_image.md).
 
 ## Step 5 — Register catalog playbooks on the GKE noetl-server
 
-<!-- TODO:
+{/* TODO:
   - From your workstation, point noetl --server at the GKE URL
   - noetl --server https://gateway.your-domain/api/noetl catalog register ...
   - Required playbooks: tests/spike/spike_e2e_test, the diagnose agent,
     bump_image (for in-cluster lifecycle), mcp/vertex-ai
   - Mention catalog versions on GKE will differ from local — that's
     expected
--->
+*/}
 
 ## Step 6 — Run the spike with Vertex backend
 
-<!-- TODO:
+{/* TODO:
   - noetl --server <gke-url> exec tests/spike/spike_e2e_test
     --payload '{"escalate_to":"none","triage_mcp_server":"mcp/vertex-ai","triage_model":"gemini-2.5-flash"}'
   - Capture exec_id, wait for terminal
@@ -113,21 +113,21 @@ Reference: [Bump Image Lifecycle](../operations/bump_image.md).
   - Walk the _meta.diagnosis_fetch telemetry — should show 1-3 polls
     typical with elapsed_seconds in the 1-3 second range for warm
     Vertex calls
--->
+*/}
 
 ## Step 7 — Validate Workload Identity is in the loop
 
-<!-- TODO:
+{/* TODO:
   - Inspect the diagnose sub-execution events
   - Find the events where the Vertex GenerateContent call was made
   - Confirm no service-account-JSON references in the call shape
   - Confirm token usage telemetry is captured in
     error.diagnosis._meta.usage
--->
+*/}
 
 ## Next steps
 
-<!-- TODO -->
+{/* TODO */}
 - [Frontend onboarding](./04-frontend-onboarding.md) — point a real
   frontend at the deployed gateway.
 - [Add a new MCP backend](./05-add-new-mcp-backend.md) — once Vertex
@@ -135,7 +135,7 @@ Reference: [Bump Image Lifecycle](../operations/bump_image.md).
 
 ## Troubleshooting
 
-<!-- TODO: top 5 GKE-specific gotchas
+{/* TODO: top 5 GKE-specific gotchas
   - aiplatform.googleapis.com not enabled
   - Workload Identity binding missing or scoped to wrong namespace
   - Auth0 callback URL mismatch
@@ -143,4 +143,4 @@ Reference: [Bump Image Lifecycle](../operations/bump_image.md).
     troubleshooting section)
   - Model availability — if gemini-2.5-flash returns 404, see the model
     availability section in vertex_ai_triage_backend.md
--->
+*/}

--- a/docs/tutorials/04-frontend-onboarding.md
+++ b/docs/tutorials/04-frontend-onboarding.md
@@ -23,7 +23,7 @@ Estimated time: 45 minutes.
 
 ## Prerequisites
 
-<!-- TODO -->
+{/* TODO */}
 - Completed [Quickstart](./01-quickstart.md) so you have a running
   gateway at `http://localhost:<port>` (local) or `https://gateway.your-domain/`
   (after [GKE production deploy](./02-gke-production-deploy.md)).
@@ -34,26 +34,26 @@ Estimated time: 45 minutes.
 
 ## Step 1 — Setup
 
-<!-- TODO:
+{/* TODO:
   - Either link to a starter template repo OR scaffold from create-vite
     with React + TypeScript
   - Add @auth0/auth0-react and @apollo/client (or urql, or vanilla
     fetch — pick one as canonical)
   - Show the directory layout
   - Reference: gateway/api-usage.md has a vanilla fetch baseline
--->
+*/}
 
 ## Step 2 — Auth0 integration
 
-<!-- TODO:
+{/* TODO:
   - Wrap the app in <Auth0Provider> with domain + client_id + redirect_uri
   - Use the loginWithRedirect / logout / getIdTokenClaims hooks
   - Show the Auth0Provider config inline
--->
+*/}
 
 ## Step 3 — Exchange Auth0 token for gateway session
 
-<!-- TODO:
+{/* TODO:
   - POST /api/auth/login with {auth0_token, auth0_domain,
     session_duration_hours}
   - Capture session_token from the response
@@ -62,11 +62,11 @@ Estimated time: 45 minutes.
     localStorage — explain why.
   - Reference: gateway/api-usage.md "Step 2: Exchange Auth0 Token for
     Session"
--->
+*/}
 
 ## Step 4 — Make a GraphQL `executePlaybook` call
 
-<!-- TODO:
+{/* TODO:
   - Apollo client setup with the session_token in Authorization header
   - The mutation:
     mutation Exec($path: String!, $payload: JSON!) {
@@ -76,22 +76,22 @@ Estimated time: 45 minutes.
     }
   - Capture executionId from the response
   - Note: alternative with vanilla fetch + custom hook
--->
+*/}
 
 ## Step 5 — Poll for completion via `getExecution`
 
-<!-- TODO:
+{/* TODO:
   - Query: getExecution(id: $id) { status result events { ... } }
   - Polling strategy: start at 500ms, exponential backoff to 4s cap,
     stop at terminal status
   - This pattern mirrors the noetl-side adaptive backoff filed in
     sync/issues/2026-05-07-noetl-adaptive-retry-backoff-tail-latency.md
     — same tradeoffs apply
--->
+*/}
 
 ## Step 6 — SSE for live execution updates
 
-<!-- TODO:
+{/* TODO:
   - GET /api/execution/{id}/stream returns a text/event-stream
   - Use EventSource API (or @microsoft/fetch-event-source for cleaner
     auth header handling)
@@ -100,11 +100,11 @@ Estimated time: 45 minutes.
     you want sub-second updates; polling for quick playbooks where
     one round-trip is enough
   - Cite repos/gateway/src/sse.rs for the server-side implementation
--->
+*/}
 
 ## Step 7 — Error handling
 
-<!-- TODO:
+{/* TODO:
   - 401 Unauthorized → session expired → trigger Auth0 re-login
   - 403 Forbidden → check_access denied → surface "permission denied"
     to user with the playbook path
@@ -113,11 +113,11 @@ Estimated time: 45 minutes.
   - Network errors → distinguish from server errors; usually
     indicates the gateway is unreachable
   - Show the try/catch + status switch as a reusable hook
--->
+*/}
 
 ## Step 8 — Production hardening
 
-<!-- TODO:
+{/* TODO:
   - HttpOnly cookies for session_token (server-side proxy required)
   - CORS config (server-side; cite repos/gateway/src/proxy.rs)
   - Token refresh strategy (gateway-side handles it; just refetch on
@@ -127,11 +127,11 @@ Estimated time: 45 minutes.
     the diagnose path of any playbook your frontend invokes —
     operators want to see latency distribution per backend over time
   - CSP headers
--->
+*/}
 
 ## Next steps
 
-<!-- TODO -->
+{/* TODO */}
 - [Self-troubleshooting playbook](./03-self-troubleshooting-playbook.md)
   — call a playbook that diagnoses its own failures from your frontend.
 - [Add a new MCP backend](./05-add-new-mcp-backend.md) — extend the
@@ -140,7 +140,7 @@ Estimated time: 45 minutes.
 
 ## Troubleshooting
 
-<!-- TODO: top 5 frontend-side gotchas
+{/* TODO: top 5 frontend-side gotchas
   - CORS errors: gateway needs the frontend origin in its allowed list
   - Auth0 redirect_uri mismatch: dev URL not registered
   - session_token not propagating: usually missing Authorization
@@ -150,4 +150,4 @@ Estimated time: 45 minutes.
   - "executionId" coming back null: usually means the playbook
     failed validation at the gateway layer; check the GraphQL
     response.errors
--->
+*/}

--- a/docs/tutorials/05-add-new-mcp-backend.md
+++ b/docs/tutorials/05-add-new-mcp-backend.md
@@ -26,7 +26,7 @@ Estimated time: 2 hours.
 
 ## Prerequisites
 
-<!-- TODO -->
+{/* TODO */}
 - Completed [Self-troubleshooting playbook](./03-self-troubleshooting-playbook.md).
 - Familiar with the
   [MCP-as-playbook pattern](../architecture/playbook_as_mcp_server.md)
@@ -37,27 +37,27 @@ Estimated time: 2 hours.
 
 ## Why pointer-swap, not branching
 
-<!-- TODO:
+{/* TODO:
   - Recap the architectural design from
     architecture/vertex_ai_triage_backend.md "Why Pointer-Swap, Not
     Branching"
   - The diagnose_execution agent calls mcp/<server> via JSON-RPC;
     swapping mcp/ollama for mcp/bedrock should be a config change,
     not a code change.
--->
+*/}
 
 ## Step 1 — Pick your hypothetical backend
 
-<!-- TODO:
+{/* TODO:
   - For this tutorial: AWS Bedrock with Claude 3.5 Sonnet
   - Mention alternatives: Azure OpenAI (gpt-4o), Together AI
     (open-source models), Anthropic on AWS (Claude direct)
   - The shape is identical; the credential surface differs
--->
+*/}
 
 ## Step 2 — Define the JSON-RPC contract
 
-<!-- TODO:
+{/* TODO:
   - Show the tools/list response shape: chat_completion tool with
     input schema {model, messages, system, temperature}
   - Show the tools/call request shape and the expected response:
@@ -65,11 +65,11 @@ Estimated time: 2 hours.
   - The contract is identical to mcp/ollama and mcp/vertex-ai —
     that's the whole point. Reference repos/ops/automation/agents/mcp/vertex-ai-stub.yaml
     as the template.
--->
+*/}
 
 ## Step 3 — Build the stub first
 
-<!-- TODO:
+{/* TODO:
   - Walk through copying vertex-ai-stub.yaml to bedrock-stub.yaml
   - Modify the canned chat_completion response to include source: "bedrock-stub"
   - Add mock _meta.usage with realistic prompt_tokens / completion_tokens
@@ -78,20 +78,20 @@ Estimated time: 2 hours.
     the prior round (ops#39) shipped vertex-ai-stub for exactly this
     reason — proves the pointer-swap before you commit to the real
     cloud calls.
--->
+*/}
 
 ## Step 4 — Wire the pointer-swap
 
-<!-- TODO:
+{/* TODO:
   - Run the spike with workload override: triage_mcp_server: mcp/bedrock-stub
   - Confirm the diagnosis source is "bedrock-stub"
   - Walk the events to show the swap worked end-to-end
   - This validates your backend's JSON-RPC contract conforms
--->
+*/}
 
 ## Step 5 — Implement the real backend
 
-<!-- TODO:
+{/* TODO:
   - Move from stub to real:
     1. Replace canned response with actual API call
     2. Bedrock: AWS SDK + IAM role via service account
@@ -105,11 +105,11 @@ Estimated time: 2 hours.
     - AWS profiles (for local testing)
   - Each backend's MCP playbook encapsulates its own credential pattern;
     diagnose_execution doesn't branch on backend type.
--->
+*/}
 
 ## Step 6 — Add a parity smoke fixture
 
-<!-- TODO:
+{/* TODO:
   - Open scripts/live_vs_persisted_parity_smoke.py
   - Add a static fixture for the new backend's response shape
   - The fixture should pass parity (live vs persisted shape match)
@@ -118,22 +118,22 @@ Estimated time: 2 hours.
   - This is the "explicit carve-out + parity test" prescription from
     bridge/outbox/event_projection_audit.md operationalized for new
     backends
--->
+*/}
 
 ## Step 7 — Document model name mapping
 
-<!-- TODO:
+{/* TODO:
   - Open docs/architecture/triage_model_selection.md
   - Add a row to the model-mapping table:
     - bedrock-stub: gemma3:4b ↔ claude-3-haiku
     - bedrock-stub: qwen3:32b ↔ claude-3.5-sonnet (escalation)
   - Operators picking bedrock get a clear mapping from local-tier to
     bedrock-tier model identities
--->
+*/}
 
 ## Step 8 — Validation sweep
 
-<!-- TODO:
+{/* TODO:
   - Run all 6 ai-meta smokes — all should pass with the new backend
     in place
   - Run the spike on the new backend, confirm:
@@ -142,11 +142,11 @@ Estimated time: 2 hours.
     - _meta.usage token counts match the cloud provider's response
     - parity smoke catches the regression case (verify by temporarily
       breaking the projection in a feature branch)
--->
+*/}
 
 ## Next steps
 
-<!-- TODO -->
+{/* TODO */}
 - Open a PR to upstream your new backend playbook to `repos/ops`.
 - File a sync issue if you discovered any architectural deltas (e.g.
   Bedrock's converse API maps to a slightly different message schema
@@ -158,7 +158,7 @@ Estimated time: 2 hours.
 
 ## Troubleshooting
 
-<!-- TODO: top 5 backend-implementation gotchas
+{/* TODO: top 5 backend-implementation gotchas
   - JSON-RPC contract drift: forgetting to populate _meta.usage breaks
     operator observability without breaking the spike
   - Credential leakage: cloud provider tokens accidentally logged in
@@ -170,4 +170,4 @@ Estimated time: 2 hours.
     requested model is unavailable
   - Cost: real cloud backends are metered; ensure _meta.usage is
     populated so operators can monitor cost per execution
--->
+*/}


### PR DESCRIPTION
Companion to docs#39. Converts HTML-comment TODO blocks to MDX-style {/* */} comments in the three stub tutorials. Fixes the second half of the 3.10 build recovery.