### PR TITLE
docs(tutorials): full content for tutorials 02 (GKE), 04 (Frontend), 05 (MCP backend)

### DIFF
--- a/docs/tutorials/02-gke-production-deploy.md
+++ b/docs/tutorials/02-gke-production-deploy.md
@@ -7,140 +7,384 @@ description: 'Provision a GKE cluster, deploy the NoETL stack with Vertex AI as 
 
 # GKE production deploy
 
-> **Status:** stub. The full walkthrough is queued for a subsequent
-> tutorial round. The structure below names every step plus the
-> existing reference doc that covers it; the next round fills in the
-> commands, expected outputs, and gotchas.
+This tutorial deploys the NoETL stack to Google Kubernetes Engine using
+the canonical `noetl_gke_fresh_stack` playbook, wires Vertex AI as the
+triage backend through Workload Identity, configures Auth0 + ingress +
+managed TLS, and validates by running the spike e2e against the
+deployed cluster with `_meta.diagnosis_fetch` telemetry visible in
+persisted events.
 
-This tutorial deploys the NoETL stack to a Google Kubernetes Engine
-cluster using the canonical
-[`noetl_gke_fresh_stack`](https://github.com/noetl/ops/blob/main/automation/gcp_gke/noetl_gke_fresh_stack.yaml)
-playbook, wires Vertex AI as the triage backend through Workload
-Identity, configures Auth0 + ingress + managed TLS, and validates by
-running the spike e2e against the deployed cluster.
-
-Estimated time: 1–2 hours including provisioning.
+Estimated time: 1–2 hours including cluster provisioning. If the
+cluster already exists, the deploy + validation portion is ~30 minutes.
 
 ## Prerequisites
 
-{/* TODO: enumerate concretely */}
 - Completed [Quickstart](./01-quickstart.md) so you understand the
-  local-cluster baseline.
-- A GCP project with billing enabled and the following APIs on:
-  `container.googleapis.com`, `aiplatform.googleapis.com`,
-  `secretmanager.googleapis.com`, `artifactregistry.googleapis.com`.
-- `gcloud` authenticated (`gcloud auth login` + `gcloud config set project <id>`).
+  local-cluster baseline and the architectural surface NoETL exercises.
+- A GCP project with billing enabled. The tutorial uses placeholder
+  `<project-id>` — substitute yours throughout.
+- The following GCP APIs enabled (operator decision; bills against your
+  project):
+  - `container.googleapis.com` (GKE)
+  - `aiplatform.googleapis.com` (Vertex AI)
+  - `secretmanager.googleapis.com` (gateway secrets)
+  - `artifactregistry.googleapis.com` (image mirror, optional but
+    recommended)
+- `gcloud` authenticated: `gcloud auth login` then
+  `gcloud config set project <project-id>`.
 - An Auth0 tenant with at least one Single Page Application client
-  configured. See [Auth Integration](../gateway/auth-integration.md)
-  for the gateway-side contract.
+  configured. See [Auth Integration](../gateway/auth-integration.md) for
+  the gateway-side contract; this tutorial assumes that page's setup is
+  complete.
 - A domain you can point at the GKE Ingress (Auth0 callback URLs need
-  to resolve).
+  to resolve before login works).
 
 ## Step 1 — Provision the cluster
 
-{/* TODO:
-  - Run noetl_gke_fresh_stack with action=provision-deploy
-  - Pick autopilot vs standard based on workload sizing
-  - The blueprint at automation/gcp_gke/blueprints/noetl-cluster-blueprint.json
-    is the source of truth for cluster shape
-  - Cite operations/gcp/gke-cloudsql-end-to-end.md for the long-form variant
-  - Walk the actual command + expected output
-*/}
+The canonical provisioning playbook is
+[`automation/gcp_gke/noetl_gke_fresh_stack`](https://github.com/noetl/ops/blob/main/automation/gcp_gke/noetl_gke_fresh_stack.yaml).
+It supports `provision`, `deploy`, `provision-deploy`, `status`, and
+`destroy` actions through a single workload knob. For a fresh cluster
+plus full stack deploy in one shot:
 
-Reference: [`automation/gcp_gke/noetl_gke_fresh_stack.yaml`](https://github.com/noetl/ops/blob/main/automation/gcp_gke/noetl_gke_fresh_stack.yaml).
+```bash
+noetl exec automation/gcp_gke/noetl-gke-fresh-stack \
+  --runtime local \
+  --payload '{
+    "action": "provision-deploy",
+    "project_id": "<project-id>",
+    "region": "us-central1",
+    "cluster_name": "noetl-cluster",
+    "release_channel": "regular",
+    "create_artifact_registry": true,
+    "repository_id": "noetl",
+    "build_images": false,
+    "noetl_image": "ghcr.io/noetl/noetl:v2.37.1",
+    "gateway_image": "ghcr.io/noetl/gateway:v2.10.0",
+    "gui_image": "ghcr.io/noetl/gui:v1.7.0"
+  }'
+```
+
+The blueprint at
+[`automation/gcp_gke/blueprints/noetl-cluster-blueprint.json`](https://github.com/noetl/ops/blob/main/automation/gcp_gke/blueprints/noetl-cluster-blueprint.json)
+is the source of truth for cluster shape — Autopilot enabled by
+default, COS_CONTAINERD nodes, Filestore + GCS Fuse CSI drivers
+configured, network policy disabled (use VPC-native controls instead).
+
+For an existing cluster (e.g. you already have `noetl-cluster` in
+`us-central1`), run with `action: "deploy"` to skip provisioning.
+
+Fetch credentials and confirm the cluster is reachable:
+
+```bash
+gcloud container clusters get-credentials noetl-cluster \
+  --region=us-central1 \
+  --project=<project-id>
+kubectl get nodes
+```
+
+For the long-form variant including Cloud SQL and IAP ingress, see
+[GKE + Cloud SQL end-to-end](../operations/gcp/gke-cloudsql-end-to-end.md).
 
 ## Step 2 — Wire Workload Identity for Vertex AI
 
-{/* TODO:
-  - Create GCP service account, bind roles/aiplatform.user
-  - Create k8s service account, annotate with Workload Identity binding
-  - Patch noetl-worker deployment to use the bound k8s SA
-  - Confirm: kubectl exec into worker, curl metadata server, validate
-    cloud-platform scope token can be retrieved
-  - Cite architecture/vertex_ai_triage_backend.md for the credential
-    surface design
-*/}
+The Vertex AI triage backend authenticates via the GKE metadata server
+with a `cloud-platform`-scoped token. No service-account JSON needs to
+land in any pod — the cluster's Workload Identity binding handles it.
+See [Vertex AI Triage Backend → Credential surface](../architecture/vertex_ai_triage_backend.md)
+for why this is the canonical pattern.
 
-The token flow goes through the GKE metadata server with the
-`https://www.googleapis.com/auth/cloud-platform` scope. See
-[Vertex AI Triage Backend → Credential surface](../architecture/vertex_ai_triage_backend.md)
-for why this is preferred over service-account JSON files in pods.
+Create the GCP service account, grant Vertex access, bind it to the
+Kubernetes service account that `noetl-worker` runs as:
+
+```bash
+GCP_SA="noetl-vertex-sa@<project-id>.iam.gserviceaccount.com"
+K8S_SA_NAMESPACE="noetl"
+K8S_SA_NAME="noetl-worker"
+
+# 1. Create the GCP service account
+gcloud iam service-accounts create noetl-vertex-sa \
+  --display-name="NoETL Vertex AI runtime SA" \
+  --project=<project-id>
+
+# 2. Grant Vertex AI user role
+gcloud projects add-iam-policy-binding <project-id> \
+  --member="serviceAccount:${GCP_SA}" \
+  --role="roles/aiplatform.user"
+
+# 3. Bind the GKE SA to the GCP SA via Workload Identity
+gcloud iam service-accounts add-iam-policy-binding ${GCP_SA} \
+  --role=roles/iam.workloadIdentityUser \
+  --member="serviceAccount:<project-id>.svc.id.goog[${K8S_SA_NAMESPACE}/${K8S_SA_NAME}]" \
+  --project=<project-id>
+
+# 4. Annotate the Kubernetes service account
+kubectl -n ${K8S_SA_NAMESPACE} annotate serviceaccount ${K8S_SA_NAME} \
+  iam.gke.io/gcp-service-account=${GCP_SA} \
+  --overwrite
+```
+
+Confirm a worker pod can fetch a token from the metadata server:
+
+```bash
+kubectl -n noetl exec deploy/noetl-worker -- \
+  curl -s -H "Metadata-Flavor: Google" \
+  "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
+  | jq -r '.token_type'
+# Expect: "Bearer"
+```
+
+If the binding is missing or scoped wrong, the worker logs Vertex calls
+returning 401 even though the Vertex API is enabled — the metadata
+server returns a token but it lacks the requested scope.
 
 ## Step 3 — Configure Auth0 callbacks
 
-{/* TODO:
-  - Add callback URLs: https://<your-gateway-host>/callback,
-    https://<your-gateway-host>/api/auth/callback
-  - Add allowed origins
-  - Capture domain + client_id + client_secret to Secret Manager
-  - Wire gateway deployment to read those secrets via External Secrets
-    Operator or CSI Secret Store driver
-  - Cite gateway/auth-integration.md and gateway/auth0-setup.md
-*/}
+The gateway exchanges the Auth0 `id_token` for a NoETL session via
+`POST /api/auth/login`. Auth0's callback URL needs to match the
+gateway's domain before any of that works.
+
+In the Auth0 dashboard for your SPA client:
+
+- **Allowed Callback URLs**: `https://<your-gateway-host>/callback`,
+  `https://<your-gateway-host>/api/auth/callback`
+- **Allowed Web Origins**: `https://<your-gateway-host>`
+- **Allowed Logout URLs**: `https://<your-gateway-host>` (and any
+  logout-redirect destinations your frontend uses)
+
+Capture the Auth0 domain + client_id + client_secret to GCP Secret
+Manager so the gateway deployment can read them via External Secrets
+Operator or the GCP CSI Secret Store driver:
+
+```bash
+echo -n "your-tenant.us.auth0.com" | gcloud secrets create auth0-domain \
+  --data-file=- --project=<project-id>
+echo -n "<client-id>" | gcloud secrets create auth0-client-id \
+  --data-file=- --project=<project-id>
+echo -n "<client-secret>" | gcloud secrets create auth0-client-secret \
+  --data-file=- --project=<project-id>
+```
+
+The gateway's `templates/secrets.yaml` (in
+`automation/gcp_gke/assets/gateway/`) maps these into the gateway pod's
+environment. See [Auth0 Setup](../gateway/auth0-setup.md) for the
+complete tenant-side configuration including custom claims and
+permission scoping.
 
 ## Step 4 — Deploy via `bump_image` lifecycle
 
-{/* TODO:
-  - Use noetl exec automation/agents/noetl/lifecycle/bump_image
-    payloads for noetl-server, noetl-worker, ollama-bridge OR skip
-    ollama-bridge if you're going pure-Vertex with no in-cluster
-    Ollama.
-  - The GHCR availability probe from ops#37 catches release races
-    automatically — see operations/bump_image.md
-  - Wait for kubectl rollout status on each
-*/}
+The `noetl_gke_fresh_stack` playbook in step 1 already deployed the
+initial images. For subsequent version bumps, use the
+[`bump_image`](../operations/bump_image.md) lifecycle agent — it gets
+you the GHCR availability probe (so a release race fails fast instead
+of timing out the kubectl rollout) and the idempotent unchanged path
+for verification.
 
-Reference: [Bump Image Lifecycle](../operations/bump_image.md).
+```bash
+# Bump noetl-server
+noetl exec noetl/lifecycle/bump_image \
+  --runtime distributed \
+  --payload '{
+    "deployment": "noetl-server",
+    "namespace": "noetl",
+    "image": "ghcr.io/noetl/noetl:v2.37.1"
+  }'
+
+# Bump noetl-worker
+noetl exec noetl/lifecycle/bump_image \
+  --runtime distributed \
+  --payload '{
+    "deployment": "noetl-worker",
+    "namespace": "noetl",
+    "image": "ghcr.io/noetl/noetl:v2.37.1"
+  }'
+
+# Wait for rollouts
+kubectl -n noetl rollout status deploy/noetl-server --timeout=300s
+kubectl -n noetl rollout status deploy/noetl-worker --timeout=300s
+```
+
+`bump_image` skips ollama-bridge if you're going pure-Vertex (no
+in-cluster Ollama). The deployment selector is name-based; if the
+deployment doesn't exist, the playbook reports `skipped` for that
+component cleanly.
 
 ## Step 5 — Register catalog playbooks on the GKE noetl-server
 
-{/* TODO:
-  - From your workstation, point noetl --server at the GKE URL
-  - noetl --server https://gateway.your-domain/api/noetl catalog register ...
-  - Required playbooks: tests/spike/spike_e2e_test, the diagnose agent,
-    bump_image (for in-cluster lifecycle), mcp/vertex-ai
-  - Mention catalog versions on GKE will differ from local — that's
-    expected
-*/}
+Point your local `noetl` CLI at the GKE noetl-server URL and register
+the playbooks the cluster needs. The default catalog defaults stay
+local-Ollama-friendly; GKE operators pass `triage_*` overrides per
+payload (see "How the choice flows" in
+[Triage Model Selection](../architecture/triage_model_selection.md)).
+
+```bash
+GKE_NOETL_URL="https://gateway.<your-domain>/api/noetl"
+
+noetl --server $GKE_NOETL_URL catalog register \
+  repos/e2e/fixtures/playbooks/spike/spike_e2e_test.yaml
+
+noetl --server $GKE_NOETL_URL catalog register \
+  repos/ops/automation/agents/troubleshoot/diagnose_execution.yaml
+
+noetl --server $GKE_NOETL_URL catalog register \
+  repos/ops/automation/agents/mcp/vertex-ai.yaml
+
+noetl --server $GKE_NOETL_URL catalog register \
+  repos/ops/automation/agents/noetl/lifecycle/bump_image.yaml
+```
+
+Catalog versions on GKE will differ from your local catalog —
+that's expected. Each environment maintains its own catalog backing
+store and version sequence.
 
 ## Step 6 — Run the spike with Vertex backend
 
-{/* TODO:
-  - noetl --server <gke-url> exec tests/spike/spike_e2e_test
-    --payload '{"escalate_to":"none","triage_mcp_server":"mcp/vertex-ai","triage_model":"gemini-2.5-flash"}'
-  - Capture exec_id, wait for terminal
-  - Confirm source=vertex-ai in the diagnosis
-  - Walk the _meta.diagnosis_fetch telemetry — should show 1-3 polls
-    typical with elapsed_seconds in the 1-3 second range for warm
-    Vertex calls
-*/}
+Validate Workload Identity, the catalog wiring, and the full
+diagnostic path in one shot:
+
+```bash
+EXEC_ID=$(noetl --server $GKE_NOETL_URL exec \
+  tests/spike/spike_e2e_test \
+  --runtime distributed \
+  --payload '{
+    "escalate_to": "none",
+    "triage_mcp_server": "mcp/vertex-ai",
+    "triage_model": "gemini-2.5-flash"
+  }' \
+  --json | jq -r '.execution_id')
+
+# Wait for terminal — typically 5–15 seconds with a warm Vertex backend.
+sleep 30
+noetl --server $GKE_NOETL_URL status "$EXEC_ID" --json > /tmp/gke_spike.json
+
+python3 scripts/spike_e2e_assert.py /tmp/gke_spike.json
+```
+
+You should see `All checks passed. NoETL-as-AI-OS spike e2e smoke is
+GREEN.` followed by `diagnosis source: vertex-ai` and
+`diagnosis category: ...`.
 
 ## Step 7 — Validate Workload Identity is in the loop
 
-{/* TODO:
-  - Inspect the diagnose sub-execution events
-  - Find the events where the Vertex GenerateContent call was made
-  - Confirm no service-account-JSON references in the call shape
-  - Confirm token usage telemetry is captured in
-    error.diagnosis._meta.usage
-*/}
+Inspect the diagnose sub-execution to confirm the call actually went
+through Vertex AI (not a fallback or a stub) and that telemetry was
+captured:
+
+```bash
+python3 - <<'PY'
+import json
+with open('/tmp/gke_spike.json') as f:
+    doc = json.load(f)
+
+for evt in doc.get('events', []):
+    diag = (
+        evt.get('result', {})
+           .get('context', {})
+           .get('error', {})
+           .get('diagnosis')
+    )
+    if not isinstance(diag, dict):
+        continue
+    meta = diag.get('_meta', {})
+    fetch = meta.get('diagnosis_fetch', {})
+    usage = meta.get('usage', {})
+    print(f"event {evt.get('event_id')} ({evt.get('node_name')}):")
+    print(f"  source = {diag.get('source')}")
+    print(f"  model  = {diag.get('model')}")
+    print(f"  poll_count       = {fetch.get('poll_count')}")
+    print(f"  elapsed_seconds  = {fetch.get('elapsed_seconds')}")
+    print(f"  prompt_tokens    = {usage.get('prompt_tokens')}")
+    print(f"  completion_tokens= {usage.get('completion_tokens')}")
+    break
+PY
+```
+
+Expected output (warm Vertex):
+
+```text
+event 62... (trigger_failure):
+  source = vertex-ai
+  model  = gemini-2.5-flash
+  poll_count       = 1
+  elapsed_seconds  = 0.064
+  prompt_tokens    = 42
+  completion_tokens= 35
+```
+
+A few things to confirm:
+
+- `source = vertex-ai` (NOT `vertex-stub`, NOT `ollama`). Confirms
+  the real backend is in the loop.
+- `model = gemini-2.5-flash` — if this comes back as something else,
+  your catalog default has drifted from your payload override.
+- `poll_count` and `elapsed_seconds` populated. The new
+  `_meta.diagnosis_fetch` telemetry from v2.37.0+ — see
+  [Vertex AI Triage Backend → Cloud latency](../architecture/vertex_ai_triage_backend.md)
+  for what cold vs warm numbers should look like.
+- `prompt_tokens` and `completion_tokens` populated. Confirms cost
+  telemetry is plumbed end-to-end; operators read these in production
+  to monitor per-execution cost.
+
+If telemetry is missing, the worker's projection layer is stripping
+it — see [Agent Failure Diagnostics → projection contract](../architecture/agent_failure_diagnostics.md)
+and verify your noetl version is at v2.37.1 or later.
 
 ## Next steps
 
-{/* TODO */}
-- [Frontend onboarding](./04-frontend-onboarding.md) — point a real
-  frontend at the deployed gateway.
+- [Frontend developer onboarding](./04-frontend-onboarding.md) — point a
+  real frontend at the deployed gateway with Auth0 login.
 - [Add a new MCP backend](./05-add-new-mcp-backend.md) — once Vertex
-  is comfortable, add a second cloud backend behind the same contract.
+  is comfortable, add a second cloud backend behind the same JSON-RPC
+  contract.
 
 ## Troubleshooting
 
-{/* TODO: top 5 GKE-specific gotchas
-  - aiplatform.googleapis.com not enabled
-  - Workload Identity binding missing or scoped to wrong namespace
-  - Auth0 callback URL mismatch
-  - GHCR rate limit during fresh deploy (operations/bump_image.md
-    troubleshooting section)
-  - Model availability — if gemini-2.5-flash returns 404, see the model
-    availability section in vertex_ai_triage_backend.md
-*/}
+**`aiplatform.googleapis.com` not enabled.** The first Vertex call
+returns a clean 403 with a link to enable. Run
+`gcloud services enable aiplatform.googleapis.com --project=<project-id>`
+and retry. Operator-driven (billing implications) — automation should
+not enable APIs autonomously.
+
+**Workload Identity binding missing or scoped to wrong namespace.**
+Vertex calls return 401 from the worker even though the API is
+enabled. Re-check the four-step binding in step 2: GCP SA exists,
+`roles/aiplatform.user` granted, `roles/iam.workloadIdentityUser`
+grants the K8s SA the right to impersonate, and the K8s SA has the
+`iam.gke.io/gcp-service-account` annotation. The metadata-server
+token-fetch test at the end of step 2 catches all four.
+
+**Auth0 callback URL mismatch.** Login redirects to Auth0, you
+authenticate, then Auth0 returns an error like "callback URL not
+allowed." Re-check the Allowed Callback URLs include both
+`/callback` and `/api/auth/callback` for your gateway domain. Auth0's
+callback comparison is exact-match including trailing slash; copy
+carefully.
+
+**GHCR rate limit during fresh deploy.** GHCR rate-limits anonymous
+pulls to ~60/hour per IP. The `bump_image` GHCR probe surfaces this
+fast with a clean error rather than a hung kubectl rollout. Workaround:
+mirror the noetl images to Artifact Registry once at deploy time, then
+point pods at the AR copy. The `noetl_gke_fresh_stack` playbook's
+`create_artifact_registry: true` knob does this automatically when
+provisioning.
+
+**Vertex returns 404 for `gemini-2.5-flash`.** Some Vertex models
+require per-project Model Garden activation. See
+[Vertex AI Triage Backend → Model availability](../architecture/vertex_ai_triage_backend.md)
+for the diagnosis flow. Workaround: pick a model that IS available in
+your project (`gcloud ai models list --region=us-central1
+--project=<project-id>` enumerates them) and override `triage_model`
+accordingly.
+
+**Spike completes but `diagnosis source` reads `ollama` instead of
+`vertex-ai`.** Your payload override didn't take. Most often this is
+because the catalog default is still `mcp/ollama` and your workload
+forgot to pass the override. Re-read the spike payload — both
+`triage_mcp_server: "mcp/vertex-ai"` AND `triage_model:
+"gemini-2.5-flash"` need to be present for the swap to work end-to-end.
+
+**`noetl --server` connection refused.** Your local CLI can't reach
+the GKE noetl-server URL. Most often the gateway URL is right but the
+`/api/noetl` path is wrong, or your DNS hasn't propagated yet. Try
+`curl https://gateway.<your-domain>/api/health` first to confirm the
+gateway itself is reachable, then debug the noetl-server path.

--- a/docs/tutorials/04-frontend-onboarding.md
+++ b/docs/tutorials/04-frontend-onboarding.md
@@ -7,11 +7,6 @@ description: 'Long-form walkthrough for building a frontend that talks to the No
 
 # Frontend developer onboarding
 
-> **Status:** stub. This tutorial is a long-form expansion of the
-> existing [Frontend Quickstart](../gateway/frontend-quickstart.md)
-> reference, with a runnable starter app and complete worked examples.
-> Queued for a subsequent tutorial round.
-
 This tutorial walks you through building a frontend that authenticates
 through Auth0, exchanges the resulting `id_token` for a NoETL gateway
 session, and calls playbooks via GraphQL with live execution updates
@@ -19,135 +14,557 @@ over SSE. By the end you have a small but complete React + TypeScript
 app that demonstrates every gateway integration concern a real frontend
 needs to handle.
 
+If you only need a short reference to copy patterns from, the
+[Frontend Quickstart](../gateway/frontend-quickstart.md) page is
+denser. This tutorial is the long-form walk through with an actually
+runnable starter.
+
 Estimated time: 45 minutes.
 
 ## Prerequisites
 
-{/* TODO */}
-- Completed [Quickstart](./01-quickstart.md) so you have a running
-  gateway at `http://localhost:<port>` (local) or `https://gateway.your-domain/`
-  (after [GKE production deploy](./02-gke-production-deploy.md)).
+- Either a local NoETL gateway from [Quickstart](./01-quickstart.md)
+  (`http://localhost:8090`) or a deployed gateway from
+  [GKE Production Deploy](./02-gke-production-deploy.md)
+  (`https://gateway.<your-domain>`).
 - Node 18+ and npm/pnpm/yarn.
 - An Auth0 tenant with a Single Page Application client configured.
-  Callback URLs need to include your dev URL (`http://localhost:5173`
-  for Vite default).
+  Callback URLs need to include `http://localhost:5173` (Vite dev
+  default) for local development. See
+  [Auth0 Setup](../gateway/auth0-setup.md) if you haven't configured
+  the tenant yet.
 
 ## Step 1 — Setup
 
-{/* TODO:
-  - Either link to a starter template repo OR scaffold from create-vite
-    with React + TypeScript
-  - Add @auth0/auth0-react and @apollo/client (or urql, or vanilla
-    fetch — pick one as canonical)
-  - Show the directory layout
-  - Reference: gateway/api-usage.md has a vanilla fetch baseline
-*/}
+Scaffold a Vite + React + TypeScript starter:
+
+```bash
+npm create vite@latest noetl-frontend -- --template react-ts
+cd noetl-frontend
+npm install
+
+# Add the libraries we'll use
+npm install @auth0/auth0-react graphql-request
+```
+
+This tutorial uses **vanilla `fetch` + `graphql-request`** as the
+canonical example — the smallest dependency footprint that still
+gets you typed GraphQL responses. Apollo Client and urql are popular
+alternatives; the contract with the gateway is identical, only the
+client-side ergonomics differ.
+
+Project structure (the bits we'll touch):
+
+```text
+src/
+  App.tsx           — root component, wraps in <Auth0Provider>
+  auth.ts           — session_token exchange + storage
+  api.ts            — gateway GraphQL client wrapper
+  hooks/
+    useExecution.ts — polling and SSE subscription helpers
+  components/
+    LoginButton.tsx
+    PlaybookRunner.tsx
+```
 
 ## Step 2 — Auth0 integration
 
-{/* TODO:
-  - Wrap the app in <Auth0Provider> with domain + client_id + redirect_uri
-  - Use the loginWithRedirect / logout / getIdTokenClaims hooks
-  - Show the Auth0Provider config inline
-*/}
+Wrap the app in `<Auth0Provider>`:
+
+```tsx
+// src/main.tsx
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { Auth0Provider } from '@auth0/auth0-react';
+import App from './App';
+
+const AUTH0_DOMAIN = import.meta.env.VITE_AUTH0_DOMAIN!;
+const AUTH0_CLIENT_ID = import.meta.env.VITE_AUTH0_CLIENT_ID!;
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <Auth0Provider
+      domain={AUTH0_DOMAIN}
+      clientId={AUTH0_CLIENT_ID}
+      authorizationParams={{
+        redirect_uri: window.location.origin,
+        scope: 'openid profile email',
+      }}
+      cacheLocation="memory"
+    >
+      <App />
+    </Auth0Provider>
+  </React.StrictMode>
+);
+```
+
+`cacheLocation="memory"` is a deliberate choice — it keeps Auth0's
+internal cache out of `localStorage`, which sidesteps a class of XSS
+attacks. We'll apply the same principle to the gateway session token
+in step 3.
+
+A minimal login button:
+
+```tsx
+// src/components/LoginButton.tsx
+import { useAuth0 } from '@auth0/auth0-react';
+
+export function LoginButton() {
+  const { isAuthenticated, loginWithRedirect, logout, user } = useAuth0();
+
+  if (isAuthenticated) {
+    return (
+      <div>
+        <span>Hi, {user?.name}</span>
+        <button onClick={() => logout({ logoutParams: { returnTo: window.location.origin } })}>
+          Log out
+        </button>
+      </div>
+    );
+  }
+  return <button onClick={() => loginWithRedirect()}>Log in</button>;
+}
+```
 
 ## Step 3 — Exchange Auth0 token for gateway session
 
-{/* TODO:
-  - POST /api/auth/login with {auth0_token, auth0_domain,
-    session_duration_hours}
-  - Capture session_token from the response
-  - Store it: HttpOnly cookie via a small server-side proxy is the
-    canonical pattern. In-memory is acceptable for a SPA. NEVER
-    localStorage — explain why.
-  - Reference: gateway/api-usage.md "Step 2: Exchange Auth0 Token for
-    Session"
-*/}
+After `loginWithRedirect` returns, you have an Auth0 `id_token` but the
+gateway needs its own session token. Exchange it via `POST
+/api/auth/login`:
+
+```ts
+// src/auth.ts
+const GATEWAY_URL = import.meta.env.VITE_GATEWAY_URL!;
+const AUTH0_DOMAIN = import.meta.env.VITE_AUTH0_DOMAIN!;
+
+let cachedSessionToken: string | null = null;
+
+export async function exchangeForSession(auth0Token: string): Promise<string> {
+  const resp = await fetch(`${GATEWAY_URL}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      auth0_token: auth0Token,
+      auth0_domain: AUTH0_DOMAIN,
+      session_duration_hours: 8,
+    }),
+  });
+  if (!resp.ok) {
+    throw new Error(`Session exchange failed: ${resp.status}`);
+  }
+  const data = await resp.json();
+  cachedSessionToken = data.session_token;
+  return data.session_token;
+}
+
+export function getSessionToken(): string | null {
+  return cachedSessionToken;
+}
+
+export function clearSession() {
+  cachedSessionToken = null;
+}
+```
+
+**Storing the session token securely.** Three options, in order of
+preference:
+
+1. **HttpOnly cookie via a server-side proxy** (best). Your
+   frontend talks to a tiny Node/Edge proxy that holds the cookie;
+   the proxy forwards GraphQL calls to the gateway with the cookie
+   attached. JavaScript in the browser never sees the token. Best
+   defense against XSS theft.
+2. **In-memory variable** (acceptable for SPAs). The pattern above —
+   `cachedSessionToken` lives in a module-level variable, dies on
+   page refresh, gets re-acquired through Auth0's silent
+   reauthentication. Vulnerable to XSS for the duration of the page
+   session, but XSS in your app is the bigger problem at that point.
+3. **`localStorage`** (DON'T). Persists across tabs and reloads,
+   which sounds nice, but means any XSS payload that runs in your
+   app permanently exfiltrates the token to attacker-controlled
+   domains. Even one third-party script with a vulnerability is
+   enough.
+
+The in-memory pattern above means users re-auth on every page reload.
+For SPAs that's usually fine; if you need cross-tab persistence,
+build the server-side proxy.
+
+Wire the exchange into the auth flow:
+
+```tsx
+// src/App.tsx
+import { useAuth0 } from '@auth0/auth0-react';
+import { useEffect, useState } from 'react';
+import { exchangeForSession } from './auth';
+import { LoginButton } from './components/LoginButton';
+import { PlaybookRunner } from './components/PlaybookRunner';
+
+export default function App() {
+  const { isAuthenticated, getIdTokenClaims } = useAuth0();
+  const [sessionReady, setSessionReady] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    (async () => {
+      const claims = await getIdTokenClaims();
+      if (!claims?.__raw) return;
+      await exchangeForSession(claims.__raw);
+      setSessionReady(true);
+    })();
+  }, [isAuthenticated, getIdTokenClaims]);
+
+  return (
+    <main>
+      <h1>NoETL Frontend</h1>
+      <LoginButton />
+      {sessionReady && <PlaybookRunner />}
+    </main>
+  );
+}
+```
 
 ## Step 4 — Make a GraphQL `executePlaybook` call
 
-{/* TODO:
-  - Apollo client setup with the session_token in Authorization header
-  - The mutation:
-    mutation Exec($path: String!, $payload: JSON!) {
-      executePlaybook(path: $path, payload: $payload) {
-        executionId status
-      }
+Build a thin GraphQL client wrapper that injects the session token:
+
+```ts
+// src/api.ts
+import { GraphQLClient, gql } from 'graphql-request';
+import { getSessionToken } from './auth';
+
+const GATEWAY_URL = import.meta.env.VITE_GATEWAY_URL!;
+
+function gatewayClient() {
+  const token = getSessionToken();
+  if (!token) throw new Error('No active session — log in first.');
+  return new GraphQLClient(`${GATEWAY_URL}/graphql`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+const EXECUTE_PLAYBOOK = gql`
+  mutation ExecutePlaybook($path: String!, $payload: JSON!) {
+    executePlaybook(path: $path, payload: $payload) {
+      executionId
+      status
     }
-  - Capture executionId from the response
-  - Note: alternative with vanilla fetch + custom hook
-*/}
+  }
+`;
+
+export interface ExecuteResult {
+  executionId: string;
+  status: string;
+}
+
+export async function executePlaybook(
+  path: string,
+  payload: Record<string, unknown>,
+): Promise<ExecuteResult> {
+  const client = gatewayClient();
+  const result = await client.request<{ executePlaybook: ExecuteResult }>(
+    EXECUTE_PLAYBOOK,
+    { path, payload },
+  );
+  return result.executePlaybook;
+}
+```
+
+A simple component that runs the spike playbook:
+
+```tsx
+// src/components/PlaybookRunner.tsx
+import { useState } from 'react';
+import { executePlaybook } from '../api';
+
+export function PlaybookRunner() {
+  const [executionId, setExecutionId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function runSpike() {
+    setError(null);
+    try {
+      const result = await executePlaybook('tests/spike/spike_e2e_test', {
+        escalate_to: 'none',
+        triage_mcp_server: 'mcp/vertex-ai',
+        triage_model: 'gemini-2.5-flash',
+      });
+      setExecutionId(result.executionId);
+    } catch (e) {
+      setError(String(e));
+    }
+  }
+
+  return (
+    <section>
+      <button onClick={runSpike}>Run spike playbook</button>
+      {executionId && <p>Started: {executionId}</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </section>
+  );
+}
+```
 
 ## Step 5 — Poll for completion via `getExecution`
 
-{/* TODO:
-  - Query: getExecution(id: $id) { status result events { ... } }
-  - Polling strategy: start at 500ms, exponential backoff to 4s cap,
-    stop at terminal status
-  - This pattern mirrors the noetl-side adaptive backoff filed in
-    sync/issues/2026-05-07-noetl-adaptive-retry-backoff-tail-latency.md
-    — same tradeoffs apply
-*/}
+Once you have an `executionId`, poll for terminal status with
+exponential backoff. The pattern mirrors the noetl-side adaptive retry
+in `_fetch_persisted_diagnosis_from_doc` — start short, grow, cap.
+
+```ts
+// src/hooks/useExecution.ts
+import { useEffect, useState } from 'react';
+import { GraphQLClient, gql } from 'graphql-request';
+import { getSessionToken } from '../auth';
+
+const GATEWAY_URL = import.meta.env.VITE_GATEWAY_URL!;
+
+const GET_EXECUTION = gql`
+  query GetExecution($id: String!) {
+    getExecution(id: $id) {
+      status
+      result
+    }
+  }
+`;
+
+const TERMINAL = new Set(['COMPLETED', 'FAILED', 'CANCELLED']);
+
+export function useExecution(executionId: string | null) {
+  const [state, setState] = useState<{
+    status: string | null;
+    result: unknown;
+    error: string | null;
+  }>({ status: null, result: null, error: null });
+
+  useEffect(() => {
+    if (!executionId) return;
+    let cancelled = false;
+    let sleep = 500; // 0.5s initial
+    const deadline = Date.now() + 60_000;
+
+    const poll = async () => {
+      while (!cancelled && Date.now() < deadline) {
+        try {
+          const token = getSessionToken();
+          const client = new GraphQLClient(`${GATEWAY_URL}/graphql`, {
+            headers: { Authorization: `Bearer ${token}` },
+          });
+          const data = await client.request<{
+            getExecution: { status: string; result: unknown };
+          }>(GET_EXECUTION, { id: executionId });
+          const { status, result } = data.getExecution;
+          if (cancelled) return;
+          setState({ status, result, error: null });
+          if (TERMINAL.has(status)) return;
+        } catch (e) {
+          setState((s) => ({ ...s, error: String(e) }));
+        }
+        await new Promise((r) => setTimeout(r, sleep));
+        sleep = Math.min(sleep * 1.5, 4000);
+      }
+    };
+
+    poll();
+    return () => {
+      cancelled = true;
+    };
+  }, [executionId]);
+
+  return state;
+}
+```
+
+The adaptive cadence (0.5s → 4s cap, 60s deadline) matches what
+v2.37.0 ships for the noetl-side diagnose-fetch loop. Same tradeoffs:
+warm path completes fast, cold path stretches without making warm
+gratuitously slow.
 
 ## Step 6 — SSE for live execution updates
 
-{/* TODO:
-  - GET /api/execution/{id}/stream returns a text/event-stream
-  - Use EventSource API (or @microsoft/fetch-event-source for cleaner
-    auth header handling)
-  - Event format: each event has a name + data payload
-  - When to use SSE vs polling: SSE for long-running playbooks where
-    you want sub-second updates; polling for quick playbooks where
-    one round-trip is enough
-  - Cite repos/gateway/src/sse.rs for the server-side implementation
-*/}
+Polling is fine for short playbooks. For long-running ones (multi-step
+ETL, anything orchestrating multiple sub-playbooks), Server-Sent
+Events deliver per-event updates without the polling overhead. The
+gateway exposes `GET /api/execution/{id}/stream` returning a
+`text/event-stream`. See [`repos/gateway/src/sse.rs`](https://github.com/noetl/gateway/blob/main/src/sse.rs)
+for the server-side implementation.
+
+The browser `EventSource` API doesn't support custom headers, so for
+authenticated streams use
+[`@microsoft/fetch-event-source`](https://www.npmjs.com/package/@microsoft/fetch-event-source):
+
+```ts
+// src/hooks/useExecutionStream.ts
+import { useEffect, useState } from 'react';
+import { fetchEventSource } from '@microsoft/fetch-event-source';
+import { getSessionToken } from '../auth';
+
+const GATEWAY_URL = import.meta.env.VITE_GATEWAY_URL!;
+
+export function useExecutionStream(executionId: string | null) {
+  const [events, setEvents] = useState<unknown[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!executionId) return;
+    const ctrl = new AbortController();
+    const token = getSessionToken();
+
+    fetchEventSource(`${GATEWAY_URL}/api/execution/${executionId}/stream`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: ctrl.signal,
+      onmessage: (msg) => {
+        try {
+          const data = JSON.parse(msg.data);
+          setEvents((prev) => [...prev, data]);
+        } catch {
+          /* skip malformed */
+        }
+      },
+      onerror: (err) => {
+        setError(String(err));
+        // throw to stop default reconnect; remove to enable auto-reconnect
+        throw err;
+      },
+    }).catch(() => {});
+
+    return () => ctrl.abort();
+  }, [executionId]);
+
+  return { events, error };
+}
+```
+
+When to use SSE vs polling: SSE for real-time progress feedback
+(progress bars, log streams, multi-step playbooks where each step's
+events are user-visible). Polling for fire-and-forget playbooks where
+the user just needs to know "done or not." Both are first-class.
 
 ## Step 7 — Error handling
 
-{/* TODO:
-  - 401 Unauthorized → session expired → trigger Auth0 re-login
-  - 403 Forbidden → check_access denied → surface "permission denied"
-    to user with the playbook path
-  - 5xx Server Error → retry with backoff up to N times, then surface
-    to user
-  - Network errors → distinguish from server errors; usually
-    indicates the gateway is unreachable
-  - Show the try/catch + status switch as a reusable hook
-*/}
+Map gateway responses to user-meaningful states:
+
+```ts
+// src/api.ts (extend)
+export class GatewayError extends Error {
+  constructor(public status: number, public detail: string) {
+    super(`${status}: ${detail}`);
+  }
+}
+
+export async function safeExecute(
+  path: string,
+  payload: Record<string, unknown>,
+): Promise<ExecuteResult> {
+  try {
+    return await executePlaybook(path, payload);
+  } catch (e: any) {
+    const status = e.response?.status ?? 0;
+    const detail = e.response?.errors?.[0]?.message ?? String(e);
+
+    if (status === 401) {
+      // Session expired. Trigger Auth0 silent re-login.
+      throw new GatewayError(401, 'Session expired — please log in again.');
+    }
+    if (status === 403) {
+      throw new GatewayError(403, `Permission denied for playbook ${path}.`);
+    }
+    if (status >= 500) {
+      throw new GatewayError(status, 'Gateway error. Please retry.');
+    }
+    throw new GatewayError(status, detail);
+  }
+}
+```
+
+In the component, catch `GatewayError` and surface user-meaningful
+copy:
+
+- **401**: trigger `loginWithRedirect()` via Auth0, then retry.
+- **403**: show the playbook path and a "contact your admin" message
+  with a copy-paste of the path so the user can ask for access.
+- **5xx**: retry up to 3 times with backoff, then show a generic
+  "service unavailable" message with a link to your status page.
+- **Network errors** (status === 0): show "gateway unreachable" — usually
+  means the user's network is offline, not a server issue.
 
 ## Step 8 — Production hardening
 
-{/* TODO:
-  - HttpOnly cookies for session_token (server-side proxy required)
-  - CORS config (server-side; cite repos/gateway/src/proxy.rs)
-  - Token refresh strategy (gateway-side handles it; just refetch on
-    401)
-  - Rate limiting / request deduplication client-side
-  - Monitoring: capture _meta.diagnosis_fetch.elapsed_seconds from
-    the diagnose path of any playbook your frontend invokes —
-    operators want to see latency distribution per backend over time
-  - CSP headers
-*/}
+Items to address before shipping:
+
+- **HttpOnly cookies** for session tokens. Build a small server-side
+  proxy (Cloudflare Worker, Vercel Edge Function, or a 50-line
+  Node/Express service) that holds the session cookie and forwards
+  GraphQL calls to the gateway. The frontend calls the proxy origin;
+  the proxy attaches the cookie. Eliminates the in-memory token's
+  XSS exposure window.
+- **CORS configuration**. The gateway needs your frontend's origin in
+  its allowed list. See [`repos/gateway/src/proxy.rs`](https://github.com/noetl/gateway/blob/main/src/proxy.rs)
+  for where this is configured server-side. Common gotcha: the
+  configured origin must match exactly including protocol and port.
+- **Token refresh**. Gateway sessions are valid for the
+  `session_duration_hours` requested at exchange time (default 8). On
+  401 from any GraphQL call, trigger Auth0 silent re-auth and a fresh
+  exchange. The Auth0 SDK's `getAccessTokenSilently` handles the
+  Auth0 side automatically.
+- **CSP headers**. Set `Content-Security-Policy: script-src 'self'`
+  on your origin. Tightening to `'self'` only is the single biggest
+  XSS mitigation you can ship.
+- **Cost monitoring**. Capture
+  `_meta.diagnosis_fetch.elapsed_seconds` and `_meta.usage.*` from
+  any playbook your frontend invokes that goes through the
+  auto-troubleshoot path. Operators want this for cost-per-execution
+  visibility — see
+  [Vertex AI Triage Backend → Cost telemetry](../architecture/vertex_ai_triage_backend.md)
+  for what to monitor.
+- **Rate limiting**. Debounce repeated `executePlaybook` calls
+  client-side; the gateway will accept many concurrent requests
+  but each one queues a real execution which costs real
+  Vertex/cluster resources.
 
 ## Next steps
 
-{/* TODO */}
 - [Self-troubleshooting playbook](./03-self-troubleshooting-playbook.md)
-  — call a playbook that diagnoses its own failures from your frontend.
+  — call a playbook that diagnoses its own failures from your
+  frontend; render the structured diagnosis dict in the UI.
 - [Add a new MCP backend](./05-add-new-mcp-backend.md) — extend the
-  platform if your frontend needs a backend the platform doesn't
-  have yet.
+  platform if your frontend needs a triage backend the platform
+  doesn't ship yet.
 
 ## Troubleshooting
 
-{/* TODO: top 5 frontend-side gotchas
-  - CORS errors: gateway needs the frontend origin in its allowed list
-  - Auth0 redirect_uri mismatch: dev URL not registered
-  - session_token not propagating: usually missing Authorization
-    header on a hook outside the auth context
-  - SSE connection drops on mobile: use fetch-event-source with
-    auto-reconnect
-  - "executionId" coming back null: usually means the playbook
-    failed validation at the gateway layer; check the GraphQL
-    response.errors
-*/}
+**CORS errors** ("`No 'Access-Control-Allow-Origin' header`"). The
+gateway hasn't been told about your frontend's origin. Add it to the
+gateway's CORS allowlist (configured in
+[`repos/gateway/src/proxy.rs`](https://github.com/noetl/gateway/blob/main/src/proxy.rs)
+on the server side; in production, often via an environment variable
+the gateway reads at startup). Restart the gateway pod after the
+config change.
+
+**Auth0 redirect_uri mismatch.** Login redirects to Auth0, you
+authenticate, then Auth0 returns "callback URL not allowed." Re-check
+the Auth0 SPA client's Allowed Callback URLs include your dev URL
+(`http://localhost:5173`) AND any production frontend URL. Auth0's
+match is exact-string including trailing slash; copy carefully.
+
+**`session_token` not propagating to GraphQL calls.** Usually a hook
+that uses `getSessionToken()` outside the auth context — gets called
+before `exchangeForSession` completes and gets `null`. Confirm the
+component that calls `executePlaybook` only renders after
+`sessionReady` is true (see step 3's `App.tsx`).
+
+**SSE connection drops silently after 30 seconds.** Usually a load
+balancer / proxy in front of the gateway with a default idle timeout
+shorter than the SSE keepalive cadence. Either tune the LB timeout up
+to 5+ minutes, or switch to long-polling. The gateway's
+[`sse.rs`](https://github.com/noetl/gateway/blob/main/src/sse.rs) emits
+keepalive comments every 15 seconds; if those aren't reaching the
+client, something between you and the gateway is buffering or
+terminating the connection.
+
+**`executionId` comes back null.** The `executePlaybook` mutation
+succeeded structurally but the playbook failed validation at the
+gateway. Check `response.errors` from the GraphQL client — typically
+"playbook not found in catalog" or "payload schema mismatch." Confirm
+the playbook is registered in the GKE catalog (per
+[GKE production deploy step 5](./02-gke-production-deploy.md)) and
+that your payload matches the playbook's `workload` schema.

--- a/docs/tutorials/05-add-new-mcp-backend.md
+++ b/docs/tutorials/05-add-new-mcp-backend.md
@@ -2,172 +2,574 @@
 title: 'Add a new MCP backend'
 sidebar_label: '05 · Add a new MCP backend'
 sidebar_position: 5
-description: 'Advanced. Build a new MCP backend behind the JSON-RPC contract used by mcp/ollama and mcp/vertex-ai. Worked example: AWS Bedrock or Azure OpenAI. About 2 hours.'
+description: 'Advanced. Build a new MCP backend behind the JSON-RPC contract used by mcp/ollama and mcp/vertex-ai. Worked example: AWS Bedrock. About 2 hours.'
 ---
 
 # Add a new MCP backend
 
-> **Status:** stub. The full walkthrough is queued for a subsequent
-> tutorial round. The structure below names every step plus the
-> existing reference doc that covers it.
+This tutorial extends the NoETL platform with a new triage backend
+behind the same JSON-RPC contract used by `mcp/ollama` and
+`mcp/vertex-ai`. The worked example uses **AWS Bedrock with Claude
+3.5 Sonnet** — same pattern applies to Azure OpenAI, Together AI,
+direct Anthropic, or any future provider.
 
-This tutorial walks you through extending the NoETL platform with a new
-triage backend behind the same JSON-RPC contract used by `mcp/ollama`
-and `mcp/vertex-ai`. The worked example uses AWS Bedrock as the
-hypothetical new backend, but the same pattern applies to Azure
-OpenAI, Anthropic on AWS, or any future provider.
-
-By the end you'll have a stub-then-real backend, registered in catalog,
-exercised end-to-end via workload override, and added to the parity
-smoke fixtures. Future contributors can use your work as the template
-for the next backend.
+By the end you'll have a stub-then-real backend, registered in
+catalog, exercised end-to-end via workload override, with parity-smoke
+fixtures extending the regression-detection net to the new shape.
 
 Estimated time: 2 hours.
 
 ## Prerequisites
 
-{/* TODO */}
-- Completed [Self-troubleshooting playbook](./03-self-troubleshooting-playbook.md).
+- Completed [Self-troubleshooting playbook](./03-self-troubleshooting-playbook.md)
+  so you understand the auto-troubleshoot dispatch path.
 - Familiar with the
   [MCP-as-playbook pattern](../architecture/playbook_as_mcp_server.md)
   and the
   [Agent Failure Diagnostics contract](../architecture/agent_failure_diagnostics.md).
-- (For the worked example) AWS account with Bedrock model access in at
-  least one region.
+- (For the worked example) AWS account with Bedrock model access in
+  at least one region. Bedrock requires per-account model
+  enablement — see "Step 1" troubleshooting if your first call
+  returns 403.
 
 ## Why pointer-swap, not branching
 
-{/* TODO:
-  - Recap the architectural design from
-    architecture/vertex_ai_triage_backend.md "Why Pointer-Swap, Not
-    Branching"
-  - The diagnose_execution agent calls mcp/<server> via JSON-RPC;
-    swapping mcp/ollama for mcp/bedrock should be a config change,
-    not a code change.
-*/}
+The `diagnose_execution` agent doesn't know what backend it's calling.
+It calls `mcp/<server>` via JSON-RPC; whichever MCP server is
+registered at that catalog path responds. Swapping `mcp/ollama` for
+`mcp/bedrock` is a config change, not a code change to the agent or
+the worker.
+
+This is the architectural payoff documented in
+[Vertex AI Triage Backend → Why Pointer-Swap, Not Branching](../architecture/vertex_ai_triage_backend.md).
+The contract you implement in this tutorial is the same one
+`mcp/ollama` and `mcp/vertex-ai` already implement. The catalog
+becomes the discriminator; operator-supplied workload overrides do
+the per-request routing.
 
 ## Step 1 — Pick your hypothetical backend
 
-{/* TODO:
-  - For this tutorial: AWS Bedrock with Claude 3.5 Sonnet
-  - Mention alternatives: Azure OpenAI (gpt-4o), Together AI
-    (open-source models), Anthropic on AWS (Claude direct)
-  - The shape is identical; the credential surface differs
-*/}
+For this tutorial: **AWS Bedrock with Claude 3.5 Sonnet** as the
+triage tier and Claude 3 Opus as the escalation tier. Substitute as
+appropriate:
+
+| Backend           | Triage model                  | Escalation model         | Credential surface          |
+|-------------------|-------------------------------|--------------------------|------------------------------|
+| AWS Bedrock       | `claude-3-5-haiku-20241022`   | `claude-3-5-sonnet`      | IAM role via service account |
+| Azure OpenAI      | `gpt-4o-mini`                 | `gpt-4o`                 | Managed Identity / API key   |
+| Together AI       | `meta-llama/Llama-3.3-70B`    | `Qwen/Qwen2.5-72B`       | API key                      |
+| Direct Anthropic  | `claude-3-5-haiku-20241022`   | `claude-3-5-sonnet`      | API key                      |
+
+Confirm Bedrock model access in your account before starting:
+
+```bash
+aws bedrock list-foundation-models \
+  --region=us-east-1 \
+  --query "modelSummaries[?contains(modelId, 'haiku') || contains(modelId, 'sonnet')].[modelId,modelName]" \
+  --output table
+```
+
+If the list is empty, you need to request model access in the Bedrock
+console (per-region, per-model). Operator decision; not something the
+playbook should automate.
 
 ## Step 2 — Define the JSON-RPC contract
 
-{/* TODO:
-  - Show the tools/list response shape: chat_completion tool with
-    input schema {model, messages, system, temperature}
-  - Show the tools/call request shape and the expected response:
-    {content: [{type: "text", text: "..."}], isError: bool, _meta: {...}}
-  - The contract is identical to mcp/ollama and mcp/vertex-ai —
-    that's the whole point. Reference repos/ops/automation/agents/mcp/vertex-ai-stub.yaml
-    as the template.
-*/}
+Every MCP triage backend implements the same `chat_completion` tool:
+
+**`tools/list` response shape:**
+
+```json
+{
+  "tools": [
+    {
+      "name": "chat_completion",
+      "description": "Generate a chat completion from messages",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "model": { "type": "string" },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "role": { "enum": ["system", "user", "assistant"] },
+                "content": { "type": "string" }
+              }
+            }
+          },
+          "system": { "type": "string" },
+          "temperature": { "type": "number" }
+        },
+        "required": ["model", "messages"]
+      }
+    }
+  ]
+}
+```
+
+**`tools/call` request:** `{ name: "chat_completion", arguments: <input matching schema> }`.
+
+**`tools/call` response shape:**
+
+```json
+{
+  "content": [{ "type": "text", "text": "<assistant reply>" }],
+  "isError": false,
+  "_meta": {
+    "backend": "bedrock",
+    "model": "anthropic.claude-3-5-haiku-20241022-v1:0",
+    "usage": {
+      "prompt_tokens": 0,
+      "completion_tokens": 0,
+      "total_tokens": 0
+    }
+  }
+}
+```
+
+The `_meta.usage` field is the cost-telemetry surface every backend
+must populate. The `_meta.backend` field disambiguates the source in
+events; consumers like the spike fixture's assertion script look at
+this to confirm the right path was exercised.
+
+The reference template is
+[`repos/ops/automation/agents/mcp/vertex-ai-stub.yaml`](https://github.com/noetl/ops/blob/main/automation/agents/mcp/vertex-ai-stub.yaml).
+Copy it as the starting point — the JSON-RPC scaffolding is identical
+across backends; only the upstream call changes.
 
 ## Step 3 — Build the stub first
 
-{/* TODO:
-  - Walk through copying vertex-ai-stub.yaml to bedrock-stub.yaml
-  - Modify the canned chat_completion response to include source: "bedrock-stub"
-  - Add mock _meta.usage with realistic prompt_tokens / completion_tokens
-  - Register in catalog: noetl catalog register
-  - The stub-first pattern is documented in the architectural design;
-    the prior round (ops#39) shipped vertex-ai-stub for exactly this
-    reason — proves the pointer-swap before you commit to the real
-    cloud calls.
-*/}
+The stub returns canned responses with the right shape, no real cloud
+calls. Lets you validate the pointer-swap and the contract before
+committing to credential plumbing. This is the same pattern that
+shipped `mcp/vertex-ai-stub` in [ops#39](https://github.com/noetl/ops/pull/39)
+before the real `mcp/vertex-ai` arrived in
+[ops#40](https://github.com/noetl/ops/pull/40).
+
+Create `repos/ops/automation/agents/mcp/bedrock-stub.yaml`:
+
+```yaml
+apiVersion: noetl.io/v2
+kind: Mcp
+metadata:
+  name: bedrock-stub
+  path: mcp/bedrock-stub
+  description: |
+    Stub MCP backend for AWS Bedrock. Returns canned chat_completion
+    responses so the pointer-swap can be validated end-to-end before
+    real Bedrock credentials and SDK calls are wired in.
+  tags: [aws, bedrock, mcp, stub, triage]
+
+spec:
+  protocol: mcp/1.0
+  provider: aws
+  managed: false
+
+  tools:
+    - name: chat_completion
+      description: Canned chat completion (stub)
+      inputSchema:
+        type: object
+        properties:
+          model: { type: string }
+          messages: { type: array }
+          system: { type: string }
+          temperature: { type: number }
+        required: [model, messages]
+
+  runtime:
+    type: playbook
+    inline:
+      - step: build_response
+        tool: python
+        code: |
+          # Canned diagnosis matching the troubleshoot agent's contract
+          diagnosis = {
+            "category": "transient_5xx",
+            "confidence": 0.78,
+            "root_cause": "Stubbed Bedrock response — replace with real Bedrock API call",
+            "suggested_action": "Wire AWS Bedrock IAM credentials and replace this stub.",
+            "source": "bedrock-stub",
+            "escalated": False,
+          }
+          result = {
+            "content": [{"type": "text", "text": diagnosis["root_cause"]}],
+            "isError": False,
+            "_meta": {
+              "backend": "bedrock-stub",
+              "model": model,
+              "usage": {
+                "prompt_tokens": 100,
+                "completion_tokens": 50,
+                "total_tokens": 150,
+              },
+            },
+            "diagnosis": diagnosis,
+          }
+        args:
+          model: "{{ workload.model }}"
+        next: [end]
+      - step: end
+        type: end
+```
+
+Register in catalog:
+
+```bash
+noetl catalog register repos/ops/automation/agents/mcp/bedrock-stub.yaml
+```
 
 ## Step 4 — Wire the pointer-swap
 
-{/* TODO:
-  - Run the spike with workload override: triage_mcp_server: mcp/bedrock-stub
-  - Confirm the diagnosis source is "bedrock-stub"
-  - Walk the events to show the swap worked end-to-end
-  - This validates your backend's JSON-RPC contract conforms
-*/}
+Validate the stub responds to the same `triage_mcp_server` workload
+override that `mcp/vertex-ai-stub` does:
+
+```bash
+EXEC_ID=$(noetl exec tests/spike/spike_e2e_test \
+  --runtime distributed \
+  --payload '{
+    "escalate_to": "none",
+    "triage_mcp_server": "mcp/bedrock-stub",
+    "triage_model": "anthropic.claude-3-5-haiku-20241022-v1:0"
+  }' \
+  --json | jq -r '.execution_id')
+
+sleep 30
+noetl status "$EXEC_ID" --json > /tmp/bedrock_stub_spike.json
+python3 scripts/spike_e2e_assert.py /tmp/bedrock_stub_spike.json
+```
+
+Confirm `diagnosis source: bedrock-stub` in the assertion output.
+Walk the events to confirm the canned `_meta.usage` made it through
+projection:
+
+```bash
+python3 - <<'PY'
+import json
+with open('/tmp/bedrock_stub_spike.json') as f:
+    doc = json.load(f)
+for evt in doc.get('events', []):
+    diag = evt.get('result', {}).get('context', {}).get('error', {}).get('diagnosis')
+    if isinstance(diag, dict) and diag.get('source') == 'bedrock-stub':
+        print(f"event {evt.get('event_id')} backend = {diag.get('_meta', {}).get('backend')}")
+        print(f"  model = {diag.get('_meta', {}).get('model')}")
+        print(f"  usage = {diag.get('_meta', {}).get('usage')}")
+        break
+PY
+```
+
+If those fields come back populated, the contract is right. Now
+replace the stub with real Bedrock calls.
 
 ## Step 5 — Implement the real backend
 
-{/* TODO:
-  - Move from stub to real:
-    1. Replace canned response with actual API call
-    2. Bedrock: AWS SDK + IAM role via service account
-    3. Convert messages → Bedrock's converse API format
-    4. Handle streaming vs non-streaming (same as Vertex; pick non-streaming for the diagnose path)
-    5. Map response → MCP chat_completion contract
-    6. Populate _meta.usage from Bedrock's usage telemetry
-  - Credential surface options:
-    - IAM role via service account (preferred, GKE Workload Identity-equivalent)
-    - Static API keys (acceptable for dev)
-    - AWS profiles (for local testing)
-  - Each backend's MCP playbook encapsulates its own credential pattern;
-    diagnose_execution doesn't branch on backend type.
-*/}
+Add `repos/ops/automation/agents/mcp/bedrock.yaml` (no `-stub` suffix
+— production playbook lives at the unsuffixed path):
+
+```yaml
+apiVersion: noetl.io/v2
+kind: Mcp
+metadata:
+  name: bedrock
+  path: mcp/bedrock
+  description: |
+    AWS Bedrock MCP backend for diagnostic triage. Uses the Bedrock
+    Converse API. Authenticates via IAM role via the GKE Workload
+    Identity binding (or SDK's default credential chain locally).
+  tags: [aws, bedrock, mcp, triage]
+
+spec:
+  protocol: mcp/1.0
+  provider: aws
+  managed: false
+
+  auth:
+    type: aws_iam
+    role_env: AWS_ROLE_ARN
+    region_env: AWS_REGION
+
+  tools:
+    - name: chat_completion
+      description: Bedrock Converse chat completion
+      inputSchema:
+        type: object
+        properties:
+          model: { type: string }
+          messages: { type: array }
+          system: { type: string }
+          temperature: { type: number }
+        required: [model, messages]
+
+  runtime:
+    type: playbook
+    inline:
+      - step: bedrock_converse
+        tool: python
+        code: |
+          import os, boto3, json
+
+          region = os.environ.get("AWS_REGION", "us-east-1")
+          client = boto3.client("bedrock-runtime", region_name=region)
+
+          # Convert OpenAI-style messages to Bedrock Converse format.
+          # Bedrock wants {role, content: [{text}]} — strip system from
+          # the message list and pass it via systemPrompts.
+          conv_messages = []
+          system_prompts = []
+          if system_prompt:
+              system_prompts.append({"text": system_prompt})
+          for msg in messages:
+              role = msg.get("role")
+              if role == "system":
+                  system_prompts.append({"text": msg.get("content", "")})
+                  continue
+              conv_messages.append({
+                  "role": role,
+                  "content": [{"text": msg.get("content", "")}],
+              })
+
+          response = client.converse(
+              modelId=model,
+              messages=conv_messages,
+              system=system_prompts or None,
+              inferenceConfig={
+                  "temperature": temperature,
+                  "maxTokens": 1024,
+              },
+          )
+
+          # Extract text from output. Bedrock returns
+          # {output: {message: {role, content: [{text}]}}, usage: {...}}.
+          text = ""
+          for block in response.get("output", {}).get("message", {}).get("content", []):
+              if "text" in block:
+                  text = block["text"]
+                  break
+
+          usage = response.get("usage", {})
+          stop_reason = response.get("stopReason")
+
+          result = {
+            "content": [{"type": "text", "text": text}],
+            "isError": False,
+            "_meta": {
+              "backend": "bedrock",
+              "model": model,
+              "request_id": response.get("ResponseMetadata", {}).get("RequestId"),
+              "usage": {
+                "prompt_tokens": usage.get("inputTokens", 0),
+                "completion_tokens": usage.get("outputTokens", 0),
+                "total_tokens": usage.get("totalTokens", 0),
+              },
+              "stop_reason": stop_reason,
+            },
+          }
+        args:
+          model: "{{ workload.model }}"
+          messages: "{{ workload.messages }}"
+          system_prompt: "{{ workload.system | default('') }}"
+          temperature: "{{ workload.temperature | default(0.0) }}"
+        next: [end]
+      - step: end
+        type: end
+```
+
+A few things worth understanding:
+
+- **Credential surface**: `boto3.client("bedrock-runtime")` uses the
+  AWS SDK's default credential chain — IAM role via service account
+  on EKS/GKE-with-IRSA-equivalent, instance profile on EC2, or
+  `~/.aws/credentials` locally. No tokens in the playbook YAML;
+  no service-account JSON anywhere.
+- **Message conversion**: OpenAI-style `{role, content}` flattens to
+  Bedrock's `{role, content: [{text}]}`. System messages move to
+  `systemPrompts` rather than prepending to the user message — same
+  decision Vertex AI's adapter makes for the same reason
+  (consistency in how the model sees system instructions across
+  turns).
+- **Response shape**: `_meta.usage` populated from Bedrock's
+  `usage.{inputTokens, outputTokens, totalTokens}` — Bedrock uses
+  different field names than OpenAI, so the adapter normalizes.
+  `_meta.request_id` from the AWS response metadata gives operators
+  a cross-correlation key into CloudWatch logs. `_meta.stop_reason`
+  surfaces Bedrock's stop reason (e.g. `end_turn`,
+  `max_tokens`, `stop_sequence`).
 
 ## Step 6 — Add a parity smoke fixture
 
-{/* TODO:
-  - Open scripts/live_vs_persisted_parity_smoke.py
-  - Add a static fixture for the new backend's response shape
-  - The fixture should pass parity (live vs persisted shape match)
-  - Add a regression fixture: same shape but with _meta stripped on the
-    persisted side — should detect NESTED_DICT_LOSS
-  - This is the "explicit carve-out + parity test" prescription from
-    bridge/outbox/event_projection_audit.md operationalized for new
-    backends
-*/}
+Per the projection audit's prescription ("explicit carve-outs +
+parity tests for future backends"), extend
+[`scripts/live_vs_persisted_parity_smoke.py`](https://github.com/noetl/ai-meta/blob/main/scripts/live_vs_persisted_parity_smoke.py)
+to cover the Bedrock-shape envelope.
+
+The smoke takes static fixtures of `(live_response, persisted_event)`
+pairs and asserts nested-dict shape parity. Add two:
+
+```python
+# In scripts/live_vs_persisted_parity_smoke.py, append to the static
+# fixtures list:
+
+BEDROCK_LIVE = {
+    "result": {
+        "context": {
+            "error": {
+                "kind": "agent.execution",
+                "code": "PLAYBOOK_FAILED",
+                "diagnosis": {
+                    "category": "transient_5xx",
+                    "confidence": 0.78,
+                    "root_cause": "Bedrock returned 503",
+                    "suggested_action": "Retry with backoff",
+                    "source": "bedrock",
+                    "_meta": {
+                        "backend": "bedrock",
+                        "model": "anthropic.claude-3-5-haiku-20241022-v1:0",
+                        "request_id": "abc-123",
+                        "usage": {
+                            "prompt_tokens": 220,
+                            "completion_tokens": 85,
+                            "total_tokens": 305,
+                        },
+                        "stop_reason": "end_turn",
+                    },
+                },
+            },
+        },
+    },
+}
+
+BEDROCK_PERSISTED_PASS = json.loads(json.dumps(BEDROCK_LIVE))  # deep copy
+BEDROCK_PERSISTED_REGRESSION = json.loads(json.dumps(BEDROCK_LIVE))
+del BEDROCK_PERSISTED_REGRESSION["result"]["context"]["error"]["diagnosis"]["_meta"]
+```
+
+Then add two test cases:
+
+- `(BEDROCK_LIVE, BEDROCK_PERSISTED_PASS)` — must PASS parity check.
+- `(BEDROCK_LIVE, BEDROCK_PERSISTED_REGRESSION)` — must FAIL with
+  `NESTED_DICT_LOSS at result.context.error.diagnosis._meta`.
+
+Run the smoke to confirm both fixtures behave as expected:
+
+```bash
+cd /Volumes/X10/projects/noetl/ai-meta
+python3 scripts/live_vs_persisted_parity_smoke.py
+```
+
+Expected output: the static-fixture count grows from 3/3 to 5/5
+(your two new fixtures + the existing three). If your "must FAIL"
+case actually passes, the smoke isn't catching the regression — debug
+the comparison logic before trusting it.
 
 ## Step 7 — Document model name mapping
 
-{/* TODO:
-  - Open docs/architecture/triage_model_selection.md
-  - Add a row to the model-mapping table:
-    - bedrock-stub: gemma3:4b ↔ claude-3-haiku
-    - bedrock-stub: qwen3:32b ↔ claude-3.5-sonnet (escalation)
-  - Operators picking bedrock get a clear mapping from local-tier to
-    bedrock-tier model identities
-*/}
+Update [`docs/architecture/triage_model_selection.md`](../architecture/triage_model_selection.md)
+to add the new backend to the model-mapping table. Append rows
+like:
+
+| Tier         | Local            | Vertex                    | Bedrock                                       |
+|--------------|------------------|---------------------------|-----------------------------------------------|
+| Triage       | `gemma3:4b`      | `gemini-2.5-flash`        | `anthropic.claude-3-5-haiku-20241022-v1:0`    |
+| Higher-quality opt-in | `gemma4:e4b` | (operator pick) | `anthropic.claude-3-5-sonnet-20241022-v2:0` |
+| Escalation   | `qwen3:32b`      | `gemini-2.5-pro`          | `anthropic.claude-3-opus-20240229-v1:0`       |
+
+This is operator-facing documentation; pick the model identifiers
+you actually validated on real Bedrock calls. Don't paste examples
+that haven't been exercised.
 
 ## Step 8 — Validation sweep
 
-{/* TODO:
-  - Run all 6 ai-meta smokes — all should pass with the new backend
-    in place
-  - Run the spike on the new backend, confirm:
-    - diagnosis source = your backend name
-    - _meta.diagnosis_fetch telemetry populated
-    - _meta.usage token counts match the cloud provider's response
-    - parity smoke catches the regression case (verify by temporarily
-      breaking the projection in a feature branch)
-*/}
+Run the full smoke battery and the spike with the real Bedrock
+backend:
+
+```bash
+# All 6 ai-meta smokes pass with the new backend in place
+python3 scripts/agent_envelope_carveout_smoke.py
+python3 scripts/gap41_diagnosis_wait_smoke.py
+python3 scripts/auto_troubleshoot_smoke.py
+python3 scripts/optional_ai_smoke.py
+python3 scripts/live_vs_persisted_parity_smoke.py     # 5/5 with Bedrock fixtures
+python3 scripts/worker_workload_forwarding_smoke.py
+
+# Real Bedrock spike
+EXEC_ID=$(noetl exec tests/spike/spike_e2e_test \
+  --runtime distributed \
+  --payload '{
+    "escalate_to": "none",
+    "triage_mcp_server": "mcp/bedrock",
+    "triage_model": "anthropic.claude-3-5-haiku-20241022-v1:0"
+  }' \
+  --json | jq -r '.execution_id')
+
+sleep 30
+noetl status "$EXEC_ID" --json > /tmp/bedrock_real.json
+python3 scripts/spike_e2e_assert.py /tmp/bedrock_real.json
+```
+
+Expected: GREEN with `diagnosis source: bedrock`, real prompt+completion
+token counts (typically 100–300 / 30–100 for the spike's failure
+context), and `_meta.request_id` populated with a real AWS request ID
+that you can grep CloudWatch for.
+
+If the parity smoke catches anything (your Bedrock response has
+nested telemetry that v2.37.1's recursive carve-out doesn't preserve)
+that's a real architectural finding — file a sync issue against
+noetl-side projection logic, don't paper over it in the playbook.
 
 ## Next steps
 
-{/* TODO */}
-- Open a PR to upstream your new backend playbook to `repos/ops`.
-- File a sync issue if you discovered any architectural deltas (e.g.
-  Bedrock's converse API maps to a slightly different message schema
-  than Vertex's GenerateContent). The pointer-swap pattern depends on
-  the JSON-RPC contract being tight; deltas need to be encoded on the
-  backend side, not surfaced to the consumer.
+- Open a PR to upstream your new backend playbook to
+  [`noetl/ops`](https://github.com/noetl/ops). The community benefits
+  when each cloud backend has a maintained reference implementation.
+- File a sync issue if you discovered any architectural deltas
+  (e.g. Bedrock's Converse API doesn't surface stop_reason in the
+  same shape as Vertex's `finishReason`). The pointer-swap pattern
+  depends on the contract being tight; deltas need to encode on the
+  backend side, not bubble up to consumers.
 - [Triage Model Selection](../architecture/triage_model_selection.md)
-  — long-form reference for backend choice and model tier semantics.
+  — long-form reference for backend choice and tier semantics now
+  that yours is documented.
 
 ## Troubleshooting
 
-{/* TODO: top 5 backend-implementation gotchas
-  - JSON-RPC contract drift: forgetting to populate _meta.usage breaks
-    operator observability without breaking the spike
-  - Credential leakage: cloud provider tokens accidentally logged in
-    the diagnose envelope's _meta — never log raw tokens
-  - Streaming vs non-streaming: cloud providers default to streaming;
-    the diagnose path needs non-streaming for variance reasons
-  - Region availability: not all models are available in all regions;
-    the diagnose playbook should fail-fast with a clear error if the
-    requested model is unavailable
-  - Cost: real cloud backends are metered; ensure _meta.usage is
-    populated so operators can monitor cost per execution
-*/}
+**Bedrock returns 403 AccessDeniedException on first call.** Per-account
+model enablement is required. Open the Bedrock console for your region,
+go to "Model access", request access for the Claude family. Approval is
+typically immediate but can take up to 30 minutes. Retry once approved.
+
+**Bedrock returns ValidationException on `converse`.** Almost always a
+message-schema mismatch — your `messages` array has shape Bedrock
+doesn't accept. Common causes: `role: "tool"` (Bedrock uses `assistant`
++ `toolUse` blocks), empty `content`, or `system` passed inside
+`messages` instead of `system`. The adapter in step 5 handles the
+common cases; if you're proxying messages from a more permissive
+source, normalize there.
+
+**Parity smoke catches a regression on Bedrock fixtures.** The most
+recent projection-preservation work (noetl#421 / v2.37.1) handles
+nested dicts under `error.diagnosis._meta` recursively. If your
+Bedrock-shape `_meta` has an additional layer (e.g.
+`_meta.usage.cost_breakdown` for fine-grained cost by tokens) and
+parity catches it, that means the recursive carve-out has an upper
+depth limit it's hitting. File against noetl with the exact shape;
+v2.37.1's `max_depth=8` should cover any realistic nesting but a real
+backend might exceed it.
+
+**Cost shows up wildly different in CloudWatch vs `_meta.usage`.**
+Bedrock's billing tracks input + output tokens separately for some
+models with different rates (e.g. Sonnet's input vs output rate).
+The `_meta.usage.total_tokens` is sum-of-both; if your operator
+dashboard prices on `total_tokens × single_rate`, it'll drift from
+the real bill. Surface input + output separately in dashboards and
+apply the right rate per direction.
+
+**`mcp/bedrock-stub` left in catalog after going to real.** Keep it
+intentionally as a regression-detector — the stub-vs-real swap is
+the smallest-possible reproducible test of the pointer-swap. The
+stub doesn't ship to production payloads (catalog defaults remain
+`mcp/ollama` locally, `mcp/vertex-ai` per-payload-override on GKE),
+so it's harmless storage. The architectural scaffolding pattern from
+[ops#39](https://github.com/noetl/ops/pull/39) keeps this pair around
+permanently.


### PR DESCRIPTION
Replaces the stubs from docs#36 with full content. ~1100 lines of new prose + working code samples across the three tutorials. All five tutorials are now complete.