### PR TITLE
docs: AI-OS doc set text pass — land catalog-ux page, polish chat→prompt tonal language across GUI/architecture/tutorials

### DIFF
--- a/docs/architecture/agent_orchestration.md
+++ b/docs/architecture/agent_orchestration.md
@@ -123,7 +123,8 @@ dominate.
       query: "{{ user_query }}"
     on_failure:
       troubleshoot: true
-      ollama_model: gemma3:4b
+      triage_mcp_server: mcp/ollama
+      triage_model: gemma3:4b
       confidence_threshold: 0.85
       escalate_to: openai
 ```
@@ -169,9 +170,12 @@ result.context.error.diagnosis
 ```
 
 When this regresses, the live step response may contain a diagnosis, but
-the persisted terminal events lose the nested object. Operators should
-run the parity smoke any time event projection, worker terminal events,
-or auto-troubleshoot handling changes.
+the persisted terminal events lose the nested object. The same projection
+discipline now covers GUI render descriptors at `result.context.render.args`
+so [prompt widgets](../gui/widgets.md) survive from worker event to persisted
+execution document. Operators should run the parity smoke any time event
+projection, worker terminal events, auto-troubleshoot handling, or render
+descriptor projection changes.
 
 Run the static fixture smoke from the `ai-meta` checkout. It does not
 need a cluster:
@@ -198,8 +202,7 @@ EXEC_ID=$(noetl exec tests/spike/spike_e2e_test \
   --payload '{"escalate_to":"none"}' \
   --json | jq -r '.execution_id')
 
-curl -s "http://localhost:8082/api/executions/${EXEC_ID}?page_size=500" \
-  > /tmp/noetl-spike-${EXEC_ID}.json
+noetl status "${EXEC_ID}" --json > /tmp/noetl-spike-${EXEC_ID}.json
 
 python3 scripts/spike_e2e_assert.py /tmp/noetl-spike-${EXEC_ID}.json
 python3 scripts/live_vs_persisted_parity_smoke.py --execution-id "${EXEC_ID}"
@@ -219,8 +222,8 @@ release until the projection path is fixed.
 |------------------------|----------------------------------------------------|----------------------------------------|
 | `troubleshoot`         | `false`                                            | per-task opt-in (overrides env)        |
 | `troubleshoot_path`    | `automation/agents/troubleshoot/diagnose_execution`| catalog path of the diagnostic agent   |
-| `ollama_model`         | `gemma3:4b`                                        | local model for first-pass triage      |
-| `ollama_mcp_server`    | `mcp/ollama`                                       | catalog path of the Ollama MCP bridge  |
+| `triage_model`         | `gemma3:4b`                                        | model for first-pass triage            |
+| `triage_mcp_server`    | `mcp/ollama`                                       | catalog path of the triage MCP backend |
 | `confidence_threshold` | `0.7`                                              | escalate when local confidence < this  |
 | `escalate_to`          | `openai`                                           | `openai` / `claude` / `none`           |
 | `openai_credential`    | `openai_token`                                     | keychain entry for the API key         |
@@ -229,7 +232,9 @@ release until the projection path is fixed.
 
 Unknown `on_failure` keys are ignored at the troubleshoot dispatch —
 they're filtered to the known set so an arbitrary key doesn't leak
-into the workload silently.
+into the workload silently. `triage_*` is the canonical naming surface;
+the older `ollama_*` aliases were removed after the worker started
+forwarding `triage_*` keys generically.
 
 ## Optional-dependency contract
 
@@ -305,7 +310,8 @@ tool:
   on_failure:
     troubleshoot: true
     troubleshoot_path: automation/agents/troubleshoot/diagnose_execution
-    ollama_model: gemma3:4b
+    triage_mcp_server: mcp/ollama
+    triage_model: gemma3:4b
     confidence_threshold: 0.7
     escalate_to: openai
 ```
@@ -316,6 +322,9 @@ tool:
   expose any playbook as an MCP tool to external clients.
 - [Self-Troubleshoot Agent](./self_troubleshoot_agent.md) — what
   `on_failure.troubleshoot: true` actually invokes.
+- [Catalog UX](../gui/catalog-ux.md) and
+  [Widgets in output](../gui/widgets.md) — how catalog resources and
+  `render: { type, args }` results surface in the terminal-style prompt.
 - [Ollama Bridge](../operations/ollama_bridge.md) — deploying the
   cheap-first inference layer the troubleshoot agent uses.
 - [Triage Model Selection](./triage_model_selection.md) — how to choose

--- a/docs/architecture/mcp_catalog_architecture.md
+++ b/docs/architecture/mcp_catalog_architecture.md
@@ -223,6 +223,11 @@ A few things worth noticing:
 The GUI's catalog browser auto-detects `kind: Mcp` entries and
 renders them as workspaces with verb-buttons:
 
+The broader [Catalog UX](../gui/catalog-ux.md) keeps Playbook, MCP,
+and Credential resources in one kind-aware navigation model. Terminal
+commands and prompt widgets then consume those same catalog paths rather
+than inventing a separate GUI-only identifier.
+
 ```
 mcp/kubernetes :: Read-only Kubernetes runtime agent backed by the Kubernetes MCP server
 
@@ -338,3 +343,7 @@ Open follow-ups (none blocking):
 - [MCP End-to-End on GKE](../operations/mcp/end-to-end-gke.md) — same architecture in the cloud
 - [Older Kubernetes MCP runbook](../operations/mcp/kubernetes-local-kind.md) — pre-architecture-PR, kept for context
 - [Sink-driven storage](sink_driven_storage) — the event/projection pattern this builds on
+- [Catalog UX](../gui/catalog-ux.md) — kind-aware catalog navigation
+  in the GUI
+- [Widgets in output](../gui/widgets.md) — structured prompt output
+  rendered from playbook step results

--- a/docs/architecture/playbook_as_mcp_server.md
+++ b/docs/architecture/playbook_as_mcp_server.md
@@ -25,6 +25,8 @@ tool's `inputSchema`; its result envelope becomes MCP content blocks.
 For the higher-level framing — how this fits with `tool: kind: mcp`
 catalog resources and the lifecycle endpoints — see
 [NoETL Catalog-Driven MCP Architecture](./mcp_catalog_architecture.md).
+For the GUI entry point into those resources, see
+[Catalog UX](../gui/catalog-ux.md).
 
 ## Wire shape — JSON-RPC 2.0
 
@@ -214,5 +216,7 @@ endpoint per playbook keeps each tool's authorization scope distinct.
 - [MCP Catalog Architecture](./mcp_catalog_architecture.md) — the
   bigger picture for `kind: Mcp` catalog resources, lifecycle
   dispatch, discovery.
+- [Widgets in output](../gui/widgets.md) — the GUI-side render
+  contract for playbook results that include `render: { type, args }`.
 - [Self-Troubleshoot Agent](./self_troubleshoot_agent.md) — a worked
   example of a playbook designed to be exposed via this endpoint.

--- a/docs/architecture/self_troubleshoot_agent.md
+++ b/docs/architecture/self_troubleshoot_agent.md
@@ -80,9 +80,9 @@ flowchart LR
 
 The `summary` / `text` / `user_message` fields all carry the same
 friendly one-liner, mirroring the GUI's `extractAgentText` heuristic
-so the run dialog renders it inline. `data.diagnosis` carries the
-structured form for programmatic callers (other playbooks,
-auto-dispatch hooks, CI integrations).
+so prompt and execution views can show a concise result inline.
+`data.diagnosis` carries the structured form for programmatic callers
+(other playbooks, auto-dispatch hooks, CI integrations).
 
 ## Workload knobs
 
@@ -90,8 +90,8 @@ auto-dispatch hooks, CI integrations).
 |------------------------|----------------------------------------------------|----------------------------------------|
 | `execution_id`         | `""` (required)                                    | which failed execution to diagnose     |
 | `noetl_url`            | `http://noetl-server.noetl.svc.cluster.local:8080` | NoETL API base                         |
-| `ollama_model`         | `gemma3:4b`                                        | local model for first-pass             |
-| `ollama_mcp_server`    | `mcp/ollama`                                       | catalog path of the Ollama bridge      |
+| `triage_model`         | `gemma3:4b`                                        | model for first-pass triage            |
+| `triage_mcp_server`    | `mcp/ollama`                                       | catalog path of the triage MCP backend |
 | `confidence_threshold` | `0.7`                                              | escalate when local confidence < this  |
 | `escalate_to`          | `openai`                                           | `openai` / `claude` / `none`           |
 | `openai_credential`    | `openai_token`                                     | keychain entry for OpenAI API key      |
@@ -113,6 +113,8 @@ Three surfaces:
        entrypoint: automation/agents/troubleshoot/diagnose_execution
        payload:
          execution_id: "{{ failed_id }}"
+         triage_mcp_server: mcp/ollama
+         triage_model: gemma3:4b
          confidence_threshold: 0.85
    ```
 
@@ -201,3 +203,6 @@ upstream availability.
   how diagnoses are waited for, fetched, projected, and regression-tested.
 - [Playbook-as-MCP-Server](./playbook_as_mcp_server.md) — how
   external MCP clients reach this agent over the wire.
+- [Catalog UX](../gui/catalog-ux.md) and
+  [Widgets in output](../gui/widgets.md) — how catalog resources and
+  rendered prompt output blocks meet in the GUI.

--- a/docs/gui/catalog-ux.md
+++ b/docs/gui/catalog-ux.md
@@ -1,0 +1,108 @@
+---
+title: Catalog UX (kind-aware navigation, version collapse, cross-field search)
+sidebar_label: Catalog UX
+sidebar_position: 5
+description: How the NoETL GUI catalog presents Playbook, MCP, and Credential resources as first-class navigable entries for terminal-style workflows.
+---
+
+# Catalog UX
+
+The catalog is the program registry for NoETL. The GUI catalog view is
+therefore not just a list of playbooks: it is the entry point for every
+resource kind a user or agent can reference from the terminal-style
+prompt.
+
+The current kind-aware surface groups resources into three primary
+tabs:
+
+- **Playbook** — executable workflows, including agent and lifecycle
+  playbooks.
+- **MCP** — Model Context Protocol backends and managed endpoints
+  registered in the catalog.
+- **Credential** — named credential records referenced by playbooks
+  and backend agents.
+
+Each tab keeps the same list shape: path, name, description, tags,
+latest version, and last-updated metadata. That consistency lets the
+prompt, catalog browser, and execution views use the same identifiers.
+
+## Search and Filters
+
+Catalog search is cross-field. A query can match:
+
+- resource path
+- display name
+- description text
+- tags
+
+The kind tab narrows the result set without changing the search
+semantics. For example, `kubernetes` on the MCP tab finds MCP-backed
+runtime entries, while the same query on the Playbook tab finds
+Kubernetes lifecycle or runtime playbooks.
+
+## Version Collapse
+
+By default, the catalog shows the latest version for each path. This is
+the safest view for day-to-day execution because a user normally wants
+the runnable current resource, not a historical row.
+
+When a user needs the full audit trail, the detail view exposes the
+version history for that path. Older versions remain addressable by
+version pin, but the main browser stays compact.
+
+## Navigation Model
+
+Catalog paths behave like breadcrumbs. A path such as:
+
+```text
+automation/agents/troubleshoot/diagnose_execution
+```
+
+can be read as:
+
+```text
+automation > agents > troubleshoot > diagnose_execution
+```
+
+Those segments give the GUI natural navigation anchors and give the
+prompt a stable token to work with. A user can browse to a resource in
+the catalog, then switch back to the prompt and run or inspect that
+same path.
+
+## Gateway Routing
+
+The GUI should treat the gateway as the browser-facing API boundary.
+Authenticated browser traffic goes through gateway routes, and the
+gateway proxies NoETL requests to the server behind the cluster
+boundary. That keeps Auth0 session validation, NATS K/V session cache
+checks, request IDs, and NoETL execution calls on one consistent path.
+
+For custom frontends, see [Build Custom UI with Gateway](custom-ui-gateway.md).
+
+## How This Pairs With Widget Output
+
+Catalog navigation helps the user find the thing to run. Widget output
+helps the user read the result once it runs.
+
+The two surfaces meet in the terminal-style prompt:
+
+1. The user discovers or runs a catalog resource.
+2. The execution writes normal text and structured events.
+3. A step can attach `render: { type, args }` to its result.
+4. The prompt renders that widget below the textual report.
+
+The widget contract is documented in
+[Embedding widgets in playbook output](widgets.md).
+
+## Future Direction
+
+The next natural step is tighter prompt integration:
+
+- clicking a catalog row can insert its path into the prompt buffer
+- search results can expose contextual actions such as `run`, `open`,
+  or `report`
+- execution rows can link back to the catalog resource and version that
+  produced them
+
+The goal is a catalog that feels like an autocomplete source for the
+prompt, not a separate application silo.

--- a/docs/gui/custom-ui-gateway.md
+++ b/docs/gui/custom-ui-gateway.md
@@ -17,6 +17,12 @@ Client UI must call:
 - `GET /events` (SSE stream for async playbook callbacks)
 - `/{gateway}/noetl/*` (authenticated REST proxy to NoETL `/api/*`)
 
+The browser-facing route is `GUI/custom frontend -> Gateway (port 8090 or
+its ingress host) -> noetl-server (port 8082 inside the cluster)`. Gateway
+validates sessions through its NATS K/V cache fast path, falls back to the
+auth playbooks when needed, and forwards request context such as the gateway
+request ID into async playbook flows.
+
 Canonical execution protocol over gateway proxy:
 - Start: `POST /noetl/execute` with `{ path|catalog_id, workload, resource_kind: "playbook" }`
 - Rerun: `POST /noetl/executions/{execution_id}/rerun` with `{ workload, resource_kind: "playbook" }`
@@ -57,6 +63,9 @@ Set UI and CLI targets:
 export VITE_GATEWAY_URL=http://localhost:8091
 export NOETL_SERVER_URL=http://localhost:8082
 ```
+
+`NOETL_SERVER_URL` is for local CLI registration and direct operator checks in
+this tutorial. Browser code should continue to use `VITE_GATEWAY_URL` only.
 
 Start your frontend locally:
 

--- a/docs/gui/terminal-console.md
+++ b/docs/gui/terminal-console.md
@@ -11,7 +11,9 @@ The NoETL GUI uses a terminal-style console as the primary navigation surface at
 noetl@kind:/execution$
 ```
 
-The context name tells the user which NoETL server or local API is currently in use. In local development, `kind` usually means the GUI is talking directly to the NoETL API running in the local kind cluster.
+The context name tells the user which NoETL server or gateway-backed API is
+currently in use. In local development, `kind` usually means the GUI is using
+the local kind stack's configured API route.
 
 The console replaces the traditional horizontal menu, but the regular dashboard/page views remain available in the lower view window. Users can navigate through commands, clickable console results, or route-specific page actions.
 
@@ -125,6 +127,12 @@ Console output can include clickable actions. For example:
 
 When a command returns structured rows, the terminal can render a compact table instead of plain text. This is useful for Kubernetes resources, catalog entries, execution lists, and future MCP providers.
 
+`report <execution_id>` also looks for a step result `render` descriptor and
+renders the widget below the textual report. The same callback path lets an
+interactive widget button emit `event.key = "command"` and run another prompt
+command. See [Embedding widgets in playbook output](widgets.md) for the
+contract.
+
 Console output rows can also be closed. Longer outputs expose compact/expanded controls so users can keep only the useful command history visible.
 
 ## Navigation Examples
@@ -160,13 +168,15 @@ Values that parse as finite numbers are sent as numbers; other values are sent a
 
 The console is the first GUI shell for NoETL as a distributed business operating system:
 
-- The catalog is the program registry.
+- The [catalog](catalog-ux.md) is the program registry.
 - A playbook execution is a process.
 - `noetl.event` is the event-sourcing log.
 - `noetl.command` is the worker command projection.
 - `noetl.execution` is the execution-state projection.
 - Kubernetes supplies the distributed runtime substrate.
 - The console, CLI, API, and scheduler are user and agent entrypoints into the same workspace.
+- Widget rendering is GUI-side only: a playbook emits `render: { type, args }`
+  in its step result, and the prompt renders it inside the command history.
 
 ## MCP and Kubernetes Commands
 

--- a/docs/gui/widgets.md
+++ b/docs/gui/widgets.md
@@ -194,9 +194,8 @@ execution report from rendering.
 
 ## Related references
 
-- Catalog UX — kind-aware navigation that pairs with widget output
-  (round 1 of the AI-OS roadmap; tracked in the ai-meta sync issue
-  until that page lands in docs).
+- [Catalog UX](catalog-ux.md) — kind-aware navigation that pairs with
+  widget output.
 - [`architecture/agent_orchestration.md`](../architecture/agent_orchestration.md)
   — how step results flow through the event source.
 - [`mlflowio/chatui`](https://github.com/mlflowio/chatui) —

--- a/docs/tutorials/01-quickstart.md
+++ b/docs/tutorials/01-quickstart.md
@@ -82,9 +82,9 @@ playbook from `repos/ops`:
 # From the ai-meta workspace root.
 noetl exec automation/development/noetl --runtime local --payload '{
   "namespace": "noetl",
-  "noetl_image": "ghcr.io/noetl/noetl:v2.37.1",
+  "noetl_image": "ghcr.io/noetl/noetl:v2.37.2",
   "gateway_image": "ghcr.io/noetl/gateway:v2.10.0",
-  "gui_image": "ghcr.io/noetl/gui:v1.7.0"
+  "gui_image": "ghcr.io/noetl/gui:v1.8.0"
 }'
 ```
 
@@ -200,6 +200,12 @@ the noetl-side fetch loop reached its first sleep. See
 [Vertex AI Triage Backend](../architecture/vertex_ai_triage_backend.md) for
 the full cloud-vs-local profile and what cold-start numbers look like.
 
+GUI v1.8.0 also renders step results that include `render: { type, args }`
+inside the terminal-style prompt. See
+[Widgets in output](../gui/widgets.md) for the contract and
+[Catalog UX](../gui/catalog-ux.md) for the kind-aware catalog surface
+that pairs with those prompt outputs.
+
 ## Step 6 — Run the regression smokes
 
 NoETL ships six prepared smoke regression detectors. Run them all to
@@ -240,7 +246,8 @@ NoETL relies on for self-troubleshooting:
   persisted diagnosis from the `persist_diagnosis` step's events.
 - **Event projection preservation** — the worker preserved the full
   nested `error.diagnosis._meta.diagnosis_fetch` dict end-to-end through
-  `_extract_control_context`.
+  `_extract_control_context`. The same projection path preserves
+  `render.args` for GUI prompt widgets in noetl v2.37.2.
 - **Live-vs-persisted parity** — the assertion script and the parity
   smoke both confirm the persisted shape matches the live response.
 

--- a/docs/tutorials/02-gke-production-deploy.md
+++ b/docs/tutorials/02-gke-production-deploy.md
@@ -59,9 +59,9 @@ noetl exec automation/gcp_gke/noetl-gke-fresh-stack \
     "create_artifact_registry": true,
     "repository_id": "noetl",
     "build_images": false,
-    "noetl_image": "ghcr.io/noetl/noetl:v2.37.1",
+    "noetl_image": "ghcr.io/noetl/noetl:v2.37.2",
     "gateway_image": "ghcr.io/noetl/gateway:v2.10.0",
-    "gui_image": "ghcr.io/noetl/gui:v1.7.0"
+    "gui_image": "ghcr.io/noetl/gui:v1.8.0"
   }'
 ```
 
@@ -187,7 +187,7 @@ noetl exec noetl/lifecycle/bump_image \
   --payload '{
     "deployment": "noetl-server",
     "namespace": "noetl",
-    "image": "ghcr.io/noetl/noetl:v2.37.1"
+    "image": "ghcr.io/noetl/noetl:v2.37.2"
   }'
 
 # Bump noetl-worker
@@ -196,7 +196,7 @@ noetl exec noetl/lifecycle/bump_image \
   --payload '{
     "deployment": "noetl-worker",
     "namespace": "noetl",
-    "image": "ghcr.io/noetl/noetl:v2.37.1"
+    "image": "ghcr.io/noetl/noetl:v2.37.2"
   }'
 
 # Wait for rollouts
@@ -328,6 +328,11 @@ A few things to confirm:
 If telemetry is missing, the worker's projection layer is stripping
 it — see [Agent Failure Diagnostics → projection contract](../architecture/agent_failure_diagnostics.md)
 and verify your noetl version is at v2.37.1 or later.
+
+If prompt widgets are missing from GUI reports, verify noetl v2.37.2
+or later is deployed. That release preserves `render.args` through the
+same worker projection chokepoint used by diagnosis telemetry, and GUI
+v1.8.0 renders the descriptor inside the terminal-style prompt.
 
 ## Next steps
 

--- a/docs/tutorials/04-frontend-onboarding.md
+++ b/docs/tutorials/04-frontend-onboarding.md
@@ -523,6 +523,11 @@ Items to address before shipping:
 
 ## Next steps
 
+- **Related GUI surfaces**:
+  [Catalog UX](../gui/catalog-ux.md) explains the kind-aware resource
+  browser a frontend developer will see in NoETL's own GUI, and
+  [Widgets in output](../gui/widgets.md) documents the `render: { type, args }`
+  contract used by terminal-style prompt output blocks.
 - [Self-troubleshooting playbook](./03-self-troubleshooting-playbook.md)
   — call a playbook that diagnoses its own failures from your
   frontend; render the structured diagnosis dict in the UI.

--- a/docs/tutorials/05-add-new-mcp-backend.md
+++ b/docs/tutorials/05-add-new-mcp-backend.md
@@ -77,6 +77,11 @@ playbook should automate.
 
 Every MCP triage backend implements the same `chat_completion` tool:
 
+`chat_completion` is the protocol-level tool name inherited from the
+MCP backend contract. It does not imply a chat UI; NoETL surfaces the
+diagnosis through execution events, prompt reports, and any structured
+`render` descriptor the playbook emits.
+
 **`tools/list` response shape:**
 
 ```json


### PR DESCRIPTION
## Summary
- Lands the missing GUI `catalog-ux.md` page and restores the cross-link from `widgets.md`.
- Applies the AI-OS chat-to-prompt terminology pass across GUI docs, architecture docs, and tutorials 01/02/04/05.
- Updates the docs to reflect the round-2 GREEN state: noetl v2.37.2 render projection, GUI v1.8.0 widget rendering, and canonical `triage_*` naming.

## Validation
- `npm run build`
- verified `/docs/gui/catalog-ux` is generated and widgets.md links to it
