### PR TITLE
docs(tutorials): walk through Anthropic provider switch in travel agent tutorial

### DIFF
--- a/docs/tutorials/07-travel-agent-with-widgets.md
+++ b/docs/tutorials/07-travel-agent-with-widgets.md
@@ -9,17 +9,17 @@ description: 'Flagship demo — a natural-language travel agent built from playb
 
 This tutorial walks through a flagship demo: a natural-language travel
 agent built entirely from NoETL playbooks. It takes a free-text query
-("flights from SFO to JFK on July 15"), classifies intent through any
-chat-completions-compatible AI provider, calls the right Amadeus
+("flights from SFO to JFK on July 15"), classifies intent through
+OpenAI or Anthropic, calls the right Amadeus
 endpoint, and returns the result as a widget tree that renders in
 both the terminal-style prompt and the travel canvas.
 
 The point isn't the travel agent specifically — it's that you can
 build this kind of agentic flow with **NoETL DSL alone**:
 
-- The AI provider is just an HTTP step. The URL, headers, and request
-  body template by `workload.ai_provider`. Swap OpenAI for Vertex AI
-  / Anthropic / Ollama by changing one workload field.
+- The AI provider switch lives in one Python step. Keychain entries
+  bind unconditionally with bare workload references, and the step
+  chooses OpenAI or Anthropic request/response shapes at runtime.
 - The Amadeus MCP server is just another playbook —
   `automation/agents/mcp/amadeus.yaml` exposes `tools/list` and
   `tools/call` per the MCP spec, so any MCP client (Claude Desktop,
@@ -40,9 +40,10 @@ templates, HTTP, and a JSON output contract.
   cluster.
 - Amadeus test API credentials in your secret manager
   (`api-key-test-api-amadeus-com`, `api-secret-test-api-amadeus-com`).
-- At least one AI provider API key in your secret manager (OpenAI is
-  the default; Anthropic / Vertex / Ollama work too — see the
-  pluggable-provider section).
+- At least one AI provider API key in your secret manager. OpenAI is
+  the default; Anthropic is supported as the second provider. Vertex
+  AI and Ollama are deferred provider rounds because they need
+  different authentication and routing patterns.
 
 ## Step 1 — Register and run the agent
 
@@ -83,28 +84,26 @@ Open `repos/ops/automation/agents/travel/runtime.yaml`. The shape:
 ```yaml
 metadata:
   agent: true
-  capabilities: [mcp:amadeus, ai:openai, ai:vertex-ai, ai:anthropic, ai:ollama]
+  capabilities: [mcp:amadeus, ai:openai, ai:anthropic]
 
 workload:
-  ai_provider: openai          # openai | vertex-ai | anthropic | ollama
+  ai_provider: openai          # openai | anthropic
   query: "Help"
   amadeus_env: test
 
 keychain:
   - name: openai_token
-    when: "{{ workload.ai_provider == 'openai' }}"
-    map: { api_key: "{{ workload.openai_secret_path }}" }
+    auth: "{{ gcp_auth }}"
+    map: { api_key: "{{ openai_secret_path }}" }
   - name: anthropic_token
-    when: "{{ workload.ai_provider == 'anthropic' }}"
-    map: { api_key: "{{ workload.anthropic_secret_path }}" }
-  - name: vertex_token
-    kind: gcp_access_token
-    when: "{{ workload.ai_provider == 'vertex-ai' }}"
+    auth: "{{ gcp_auth }}"
+    map: { api_key: "{{ anthropic_secret_path }}" }
   # Amadeus OAuth — same for every run regardless of AI provider.
   - name: amadeus_credentials
+    auth: "{{ gcp_auth }}"
     map:
-      client_id: "{{ workload.amadeus_key_path }}"
-      client_secret: "{{ workload.amadeus_secret_path }}"
+      client_id: "{{ amadeus_key_path }}"
+      client_secret: "{{ amadeus_secret_path }}"
   - name: amadeus_token
     kind: oauth2
     auto_renew: true
@@ -118,44 +117,81 @@ keychain:
 workflow:
   - step: classify_intent
     tool:
-      kind: http
-      method: POST
-      url: "{{ ... templated by workload.ai_provider ... }}"
-      headers: { ... templated by workload.ai_provider ... }
-      payload: { ... templated by workload.ai_provider ... }
-  # ... parse_classification → branch by intent → render → persist ...
+      kind: python
+      input:
+        query: "{{ workload.query }}"
+        requested_provider: "{{ workload.ai_provider }}"
+        openai_api_key: "{{ keychain.openai_token.api_key | default('') }}"
+        anthropic_api_key: "{{ keychain.anthropic_token.api_key | default('') }}"
+  # ... classify_intent -> branch by intent -> render as workflow tail ...
 ```
 
-That's the thesis: the Jinja conditionals make a single HTTP step
-work against any provider.
+That's the thesis: keychain stays boring and unconditional, while the
+normal workflow step owns provider selection, response unwrapping, and
+fallback metadata.
 
 ## Step 3 — Pluggable AI provider
 
-The classify step's URL is a Jinja conditional:
+The classify step is a single Python step. It picks the provider,
+builds the right request shape, unwraps the provider-specific response
+shape, and emits the same uniform fields for every downstream branch:
+`intent`, `origin`, `destination`, `departureDate`, `adults`, `city`,
+`keyword`, `effective_provider`, `provider_fallback_reason`, and
+`json_str` for SQL audit.
 
-```yaml
-url: |
-  {{
-    'https://api.openai.com/v1/chat/completions' if workload.ai_provider == 'openai'
-    else ('https://us-central1-aiplatform.googleapis.com/v1/projects/' ~ workload.gcp_project ~ '/locations/us-central1/publishers/google/models/gemini-2.5-flash:generateContent') if workload.ai_provider == 'vertex-ai'
-    else 'https://api.anthropic.com/v1/messages' if workload.ai_provider == 'anthropic'
-    else (workload.ollama_bridge_url ~ '/v1/chat/completions')
-  }}
+```python
+requested = (requested_provider or "openai").strip().lower()
+effective_provider = requested if requested in ("openai", "anthropic") else "openai"
+provider_fallback_reason = None
+
+if requested == "anthropic" and not (anthropic_api_key or "").strip():
+    effective_provider = "openai"
+    provider_fallback_reason = "anthropic token missing"
+
+text = _anthropic_text() if effective_provider == "anthropic" else _openai_text()
+parsed = json.loads(_strip_markdown_fences(text) or "{}")
+
+result = {
+    "intent": _normalise_intent(parsed.get("intent")),
+    "origin": _coerce(parsed.get("origin")),
+    "destination": _coerce(parsed.get("destination")),
+    "departureDate": _coerce(parsed.get("departureDate")),
+    "adults": int(parsed.get("adults") or 1),
+    "city": _coerce(parsed.get("city")),
+    "keyword": _coerce(parsed.get("keyword")),
+    "requested_provider": requested,
+    "effective_provider": effective_provider,
+    "provider_fallback_reason": provider_fallback_reason,
+}
+result["json_str"] = json.dumps(result, separators=(",", ":"))
 ```
 
-Headers and request body are similar conditionals. Switching providers
-is one workload field:
+The code follows the
+[Playbook authoring guide](../reference/playbook_authoring_guide.md):
+bare keychain references, no keychain `when:` predicates, no Jinja
+conditionals for provider-specific URLs, and pre-serialized JSON for
+SQL audit.
+
+Switching between the two supported classifiers is one workload field:
 
 ```text
-travel --provider vertex-ai flights from SFO to JFK on July 15
+travel --provider openai flights from SFO to JFK on July 15
 travel --provider anthropic locations near Boston
-travel --provider ollama help
+travel --provider anthropic flights from SFO to JFK on 2026-07-15
 ```
 
 The `--provider` flag in NoetlPrompt's `travel` verb threads the
-chosen provider into the workload. The `keychain` block uses
-`when:` predicates so only the matching provider's token is bound for
-the run.
+chosen provider into the workload. The rendered status pill shows the
+actual `effective_provider`, so an Anthropic run says
+`effective_provider=anthropic`. If Anthropic is requested but its
+secret is not available in the environment, the classifier snaps back
+to OpenAI and records `provider_fallback_reason="anthropic token
+missing"` in the result envelope.
+
+Vertex AI and Ollama stay deferred in
+`sync/issues/2026-05-09-travel-agent-widget-flagship.md`: Vertex needs
+a `gcp_access_token` / ADC design pass, and Ollama needs the in-cluster
+bridge URL wired in the target cluster.
 
 ## Step 4 — Widget output
 
@@ -172,7 +208,7 @@ render = {
             {"type": "app:text", "args": {"title": "Query", "message": query}},
             {"type": "app:row", "args": {"children": [
                 {"type": "app:statusbar", "args": {"text": f"intent=flights", "styleKey": "success"}},
-                {"type": "app:statusbar", "args": {"text": f"provider={provider}", "styleKey": "info"}},
+                {"type": "app:statusbar", "args": {"text": f"effective_provider={provider}", "styleKey": "info"}},
             ]}},
             {"type": "app:carousel", "args": {"widgets": [_offer_card(o) for o in offers]}},
             {"type": "app:row", "args": {"children": [
@@ -245,11 +281,10 @@ You can build agentic flows like the travel agent without writing any
 Python plug-ins, without forking NoETL, without standing up a
 separate AI gateway. The DSL is the templating layer:
 
-- **Pluggable providers**: any chat-completions-compatible AI is one
-  Jinja conditional away. Provider-specific shape drift (Vertex's
-  `contents`/`parts`, Anthropic's `system` field) is handled in a
-  small `parse_classification` Python step that marshals the response
-  into a uniform schema.
+- **Pluggable providers**: OpenAI and Anthropic share one merged
+  `classify_intent` Python step. Provider-specific shape drift stays
+  local to that step, and downstream branches read the uniform
+  classification fields plus `effective_provider`.
 - **Pluggable surfaces**: the agent (single flow) and the MCP server
   (tool catalog) wrap the same capability. The catalog kinds
   (`Playbook`, `Mcp`, `Credential`) make discovery uniform.
@@ -270,9 +305,9 @@ rendering surface."
 - **Phase 2** of this round adds the Amadeus MCP server's
   agent-to-MCP plumbing so the travel agent can use the MCP tools
   internally rather than calling Amadeus HTTP directly.
-- **Phase 3** is provider parity smokes — running the agent against
-  all four providers to confirm the parameterisation works in
-  practice.
+- **Phase 3** is provider parity smokes — adding Vertex AI and Ollama
+  once their auth/routing designs are ready, then running all
+  providers through the same intent branches.
 
 ## Related references
 


### PR DESCRIPTION
## Summary
- update tutorial 07 for the OpenAI + Anthropic merged Python classifier
- replace the old Jinja conditional provider example with authoring-guide-compliant keychain and classify_intent snippets
- document effective_provider/provider_fallback_reason and deferred Vertex/Ollama provider rounds

## Verification
- npm install
- npm run build