### PR TITLE
docs(tutorials): use enabled Vertex project in travel tutorial

### DIFF
--- a/docs/tutorials/07-travel-agent-with-widgets.md
+++ b/docs/tutorials/07-travel-agent-with-widgets.md
@@ -91,7 +91,7 @@ workload:
   ai_provider: openai          # openai | anthropic | vertex-ai
   query: "Help"
   amadeus_env: test
-  vertex_project: noetl-cluster
+  vertex_project: noetl-demo-19700101
   vertex_region: us-central1
   vertex_model: gemini-2.5-flash
 


### PR DESCRIPTION
## Summary\n- update the travel tutorial's Vertex project example to noetl-demo-19700101\n- keeps the snippet aligned with the GKE project where Vertex AI is enabled\n\n## Validation\n- npm run build