### PR TITLE
docs(kind): remove gcs-credentials placeholder; clarify GKE Workload Identity auth

### DIFF
--- a/docs/operations/mcp/end-to-end-gke.md
+++ b/docs/operations/mcp/end-to-end-gke.md
@@ -111,12 +111,10 @@ NOETL_TAG=$(gh release list --repo noetl/noetl --limit 1 --json tagName -q '.[0]
 TARGET_IMAGE="ghcr.io/noetl/noetl:${NOETL_TAG}"
 
 kubectl apply -f ci/manifests/noetl/namespace/
-if ! kubectl get secret gcs-credentials -n noetl >/dev/null 2>&1; then
-  # Real GCS credentials live here in production. The placeholder
-  # is only good enough for non-GCS-backed playbooks.
-  kubectl create secret generic gcs-credentials -n noetl \
-    --from-literal=gcs-key.json='{}'
-fi
+# GKE uses Workload Identity for GCP API access — no key file or
+# gcs-credentials secret is needed. The worker deployment does not
+# mount GOOGLE_APPLICATION_CREDENTIALS; google.auth.default() picks
+# up the GKE metadata-server token automatically.
 kubectl apply -f ci/manifests/noetl/rbac.yaml
 
 for manifest in ci/manifests/noetl/*.yaml; do

--- a/docs/operations/mcp/end-to-end-local-kind.md
+++ b/docs/operations/mcp/end-to-end-local-kind.md
@@ -111,9 +111,11 @@ echo "Deploying ${NOETL_TAG}"
 
 # Apply namespace + RBAC + manifests
 kubectl apply -f ci/manifests/noetl/namespace/
-if ! kubectl get secret gcs-credentials -n noetl >/dev/null 2>&1; then
-  kubectl create secret generic gcs-credentials -n noetl --from-literal=gcs-key.json='{}'
-fi
+# Note: no GCP credentials are provisioned by default on kind.
+# The worker deployment no longer mounts a gcs-credentials secret.
+# If a playbook requires GCP API access from a kind worker, mount a
+# real SA JSON key as a secret and add GOOGLE_APPLICATION_CREDENTIALS
+# back to the deployment out-of-band — Workload Identity is GKE-only.
 kubectl apply -f ci/manifests/noetl/rbac.yaml
 
 # Substitute the image placeholder and apply


### PR DESCRIPTION
## Summary

- Both end-to-end guides instructed operators to create a `gcs-credentials` secret populated with `{}` before deploying. This placeholder, combined with `GOOGLE_APPLICATION_CREDENTIALS` in the worker deployment, caused `google.auth.default()` to read an empty key file and raise `DefaultCredentialsError: ... Type is None` on kind.
- The worker deployment manifest has been fixed (see noetl/noetl#431 and noetl/ops#83) to remove the env var and mount entirely. The docs are updated to match.

## Changes

- `docs/operations/mcp/end-to-end-local-kind.md`: replace the `kubectl create secret gcs-credentials` block with a comment explaining that no GCP credentials are provisioned by default on kind and how to add them out-of-band if needed.
- `docs/operations/mcp/end-to-end-gke.md`: replace the placeholder-secret block with a comment explaining that GKE uses Workload Identity and no key file or secret is required.

## Impact

- Operators following the kind guide will no longer accidentally poison the ADC path.
- The GKE guide now correctly describes the Workload Identity flow.
- Kind operators who need real GCP API access have clear instructions to mount a real SA JSON key out-of-band.

## Test plan

- [ ] Follow the updated kind guide end-to-end; confirm the worker starts and `google.auth.default()` no longer errors on the placeholder.
- [ ] Confirm the GKE guide still produces a healthy deployment via Workload Identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)