### PR TITLE
docs(operations): warn that --set gateway_cors_allowed_domains replaces

### DIFF
--- a/docs/operations/cloudflare/pages-gui-tunnel-gateway.md
+++ b/docs/operations/cloudflare/pages-gui-tunnel-gateway.md
@@ -56,6 +56,39 @@ callback URL, logout URL, and allowed web-origin configuration explicit per
 domain. Do not use a wildcard unless the deployment is intentionally
 multi-tenant and the auth policy is designed for that.
 
+:::caution Adding a new domain? Pass the full CORS list, not just the new one
+
+When deploying via the `noetl_gke_fresh_stack.yaml` playbook in `repos/ops`,
+the `gateway_cors_allowed_domains` workload variable is a single string.
+Passing `--set gateway_cors_allowed_domains='new.example.com'` **replaces**
+the playbook's default and drops every other production frontend that was in
+the list (for example, `travel.mestumre.dev`). The browser symptom is
+`NetworkError when attempting to fetch resource` on every Gateway call — the
+preflight returns HTTP 200 but without an `access-control-allow-origin`
+header for the dropped origin.
+
+To add a new browser-callable domain safely:
+
+1. Read the current default for `gateway_cors_allowed_domains` in
+   `automation/gcp_gke/noetl_gke_fresh_stack.yaml`.
+2. Append the new domain and pass the **full** comma-separated list to
+   `--set gateway_cors_allowed_domains=...`.
+3. After the rollout, confirm the deployment env contains every expected
+   origin:
+
+   ```bash
+   kubectl get deploy -n gateway gateway \
+     -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CORS_ALLOWED_ORIGINS")].value}'
+   ```
+
+If a deployment has already shipped without a required origin, the
+in-cluster hotfix is `kubectl set env -n gateway deployment/gateway
+CORS_ALLOWED_ORIGINS="..."` followed by a rollout. The patch only lasts
+until the next `helm upgrade`; always follow it with a playbook re-deploy
+that bakes the corrected list into the release.
+
+:::
+
 ## Cloudflare API Tokens
 
 Use Cloudflare **API tokens**, not the Global API Key.


### PR DESCRIPTION
## Summary
- Add a Caution callout under the **Multiple Domains** section of `docs/operations/cloudflare/pages-gui-tunnel-gateway.md` explaining that the `gateway_cors_allowed_domains` workload variable is a single string, so `--set gateway_cors_allowed_domains='new.example.com'` **replaces** the playbook default and drops every other production frontend (e.g. `travel.mestumre.dev`).
- Spell out the browser symptom: `NetworkError when attempting to fetch resource` (Firefox) / `Failed to fetch` (Chrome), with the gateway preflight returning HTTP 200 but no `access-control-allow-origin` for the dropped origin.
- Document the safe sequence (read default, append, pass full list, verify with `kubectl jsonpath`), and the in-cluster hotfix (`kubectl set env` + rollout) plus the requirement to follow it with a playbook re-deploy that bakes the corrected list into the helm release.

## Why
On 2026-05-15 a gateway redeploy on GKE shipped `CORS_ALLOWED_ORIGINS` without `https://travel.mestumre.dev`, so the travel app at `travel.mestumre.dev` saw `NetworkError when attempting to fetch resource` on every gateway call until the in-cluster patch landed. Pairs with [noetl/ops#93](https://github.com/noetl/ops/pull/93), which adds the same warning to the deploy README and fixes the production-profile example so future operators don't copy a regression-causing command.

## Test plan
- [ ] Build the docs site locally and verify the `:::caution` admonition renders.
- [ ] Cross-check the bash snippet matches the production hotfix actually applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)