### PR TITLE
Document worker IPC metrics status

### DIFF
--- a/docs/features/noetl_distributed_runtime_spec.md
+++ b/docs/features/noetl_distributed_runtime_spec.md
@@ -642,11 +642,12 @@ Implementation status:
 - `ArrowIpcSharedMemoryCache` now provides the first Tier 1.5 implementation surface in `noetl.core.storage.ipc_cache`: budget enforcement, POSIX shared-memory allocation, `IpcHint` creation, read/attach, delete, and expired-lease sweep.
 - `TempStore.put_ipc_bytes` / `get_ipc_bytes` now provide an explicit raw Arrow IPC path: durable bytes are always written, IPC admission is optional, and reads fall back to the durable tier when the shared-memory hint is expired or missing.
 - `TempStore.ipc_stats()` exposes local counters for admission attempts/success/failures, read attempts/hits/misses, and durable fallback reads.
-- `/metrics` now exports the server process's TempStore IPC counters as `noetl_storage_ipc_*` Prometheus metrics, plus `noetl_storage_ipc_read_hit_ratio`. Worker-process metric scraping remains follow-up work unless workers are run with an HTTP metrics sidecar.
+- `/metrics` now exports the server process's TempStore IPC counters as `noetl_storage_ipc_*` Prometheus metrics, plus `noetl_storage_ipc_read_hit_ratio`.
+- Worker processes can expose their own TempStore IPC counters with `NOETL_WORKER_METRICS_PORT`. The endpoint is intentionally lightweight (`/health`, `/metrics`), suppresses scrape access logs, and labels counters by `worker_id`, `worker_pool`, and `runtime` so pod-level cache admission/read behavior is visible independently from server metrics. The Helm chart publishes this as the `noetl-worker-metrics` headless service by default.
 - `noetl.core.storage.arrow_ipc` now provides the runtime serialization primitive: `rows_to_arrow_ipc` and `arrow_ipc_to_rows`. Schema digests are computed from Arrow's serialized schema, not from row values, so replay/projector code can compare logical frame shape independently from payload content.
 - `cursor_worker` now writes multi-row frame captures through this path when `frame_policy.max_rows > 1` or `NOETL_CURSOR_FRAME_CAPTURE_ENABLED=true`. `NOETL_CURSOR_FRAME_IPC_ENABLED=false` disables only the same-node IPC admission; the durable payload write remains authoritative.
 - The durable `ResultRef` remains authoritative; consumers must treat expired or missing IPC hints as cache misses and fall back through durable storage.
-- Worker-side metrics export and aggregation across pods remains tracked by `noetl/noetl#438`.
+- Worker-side metrics aggregation into dashboards and colocated worker/projector validation remains tracked by `noetl/noetl#438`.
 
 ### 6.4 Producer / consumer protocol
 
@@ -1165,7 +1166,7 @@ Goal: add zero-copy data plane for colocated workers and projectors.
 - Producer worker writes RecordBatch to shm + Tier 3; emits hint in envelope.
 - Consumer (projector, reducer, downstream stage) checks hint, attaches, falls back.
 - Per-node IPC budget + grace + reaper.
-- Metric: `tier15_hit_ratio` per consumer.
+- Metrics: `noetl_storage_ipc_read_hit_ratio` and `noetl_storage_ipc_*` counters per server/worker process; dashboard rollups should group by worker pool, runtime, node, and tenant when those labels become available.
 
 Verification:
 


### PR DESCRIPTION
## Summary
- update the distributed runtime spec now that worker IPC metrics are exposed directly
- document the Helm-published noetl-worker-metrics service
- replace the Phase 3 metric wording with the current noetl_storage_ipc_* counters and hit-ratio naming

## Validation
- docs-only change

Refs noetl/noetl#438