### PR TITLE
Document Arrow result-ref resolver path

### DIFF
--- a/docs/features/noetl_distributed_runtime_spec.md
+++ b/docs/features/noetl_distributed_runtime_spec.md
@@ -645,6 +645,7 @@ Implementation status:
 - `/metrics` now exports the server process's TempStore IPC counters as `noetl_storage_ipc_*` Prometheus metrics, plus `noetl_storage_ipc_read_hit_ratio`. Worker-process metric scraping remains follow-up work unless workers are run with an HTTP metrics sidecar.
 - `noetl.core.storage.arrow_ipc` now provides the runtime serialization primitive: `rows_to_arrow_ipc` and `arrow_ipc_to_rows`. Schema digests are computed from Arrow's serialized schema, not from row values, so replay/projector code can compare logical frame shape independently from payload content.
 - `cursor_worker` now writes multi-row frame captures through this path when `frame_policy.max_rows > 1` or `NOETL_CURSOR_FRAME_CAPTURE_ENABLED=true`. `NOETL_CURSOR_FRAME_IPC_ENABLED=false` disables only the same-node IPC admission; the durable payload write remains authoritative.
+- `TempStore.resolve(result_ref)` is Arrow-aware for `application/vnd.apache.arrow.stream` references: it attempts the same-node IPC hint first, falls back to durable bytes, then decodes to row dictionaries only at the consumer boundary. Generic JSON result refs continue through the existing JSON resolver.
 - The durable `ResultRef` remains authoritative; consumers must treat expired or missing IPC hints as cache misses and fall back through durable storage.
 - Worker-side metrics export and aggregation across pods remains tracked by `noetl/noetl#438`.
 


### PR DESCRIPTION
## Summary
- document that TempStore.resolve is Arrow-aware for Arrow stream payload refs
- clarify that IPC hints are attempted before durable bytes and decoding happens at the consumer boundary

## Validation
- docs-only change

Refs noetl/noetl#438