### PR TITLE
Document business object replay fold

### DIFF
--- a/docs/features/noetl_distributed_runtime_spec.md
+++ b/docs/features/noetl_distributed_runtime_spec.md
@@ -63,6 +63,7 @@ Latest implementation checkpoint:
 - 2026-05-20 runtime-event topology update: `noetl/noetl#496` enriches worker-reported runtime events with `meta.locality` and a canonical `meta.worker_locator` from the shared topology helper. Explicit caller-provided locality or locator metadata remains authoritative, so event replay can distinguish observed worker identity from producer-owned placement context.
 - 2026-05-20 command-claim topology update: `noetl/noetl#497` lets command claim requests carry optional worker locality and records `locality`, `worker_locator`, `source_locality`, and placement evaluation on `command.claimed` metadata. Existing clients remain compatible, while topology-aware workers make command ownership replayable by placement distance.
 - 2026-05-20 replay command projection update: `noetl/noetl#498` folds `command.issued`, `command.claimed`, `command.started`, and terminal command events into the deterministic replay state. The reconstructed command view now carries stage/frame linkage, parent command id, worker id, locality, `worker_locator`, source locality, and placement evaluation, closing the command-ownership gap in point-in-time replay.
+- 2026-05-20 business-object replay update: `noetl/noetl#499` adds a generic `business_objects` replay projection for events that explicitly identify a domain object through `aggregate_type=business_object` or business-object metadata. The fold records object identity, status, version, event lineage, attributes, and payload references without introducing storage-specific logic.
 
 ---
 
@@ -224,9 +225,9 @@ Implementation status:
 - The live reader tolerates pre-migration event tables during rolling rollout. If the additive tenant/org envelope columns are not present yet, replay treats only `tenant_id=default` and `organization_id=default` as visible legacy events.
 - A core replay upcaster registry now exists in Phase 0 (`noetl.core.replay.EventUpcasterRegistry`) and is wired into `ReplayService.replay_state`. The default registry preserves legacy events as `schema_name=noetl.event`, `schema_version=1`.
 - Replay state includes `upcaster_registry_digest`, a stable SHA-256 digest of the registered `(schema_name, from_version)` transitions used for the fold.
-- A golden replay corpus now lives under `tests/fixtures/replay/` in `repos/noetl` and asserts a stable fold checksum for execution, command, stage, frame, payload-reference, and registry-digest state.
+- A golden replay corpus now lives under `tests/fixtures/replay/` in `repos/noetl` and asserts a stable fold checksum for execution, command, business-object, stage, frame, payload-reference, and registry-digest state.
 - Event-position snapshot selection now exists for `projection_snapshot` rows with `aggregate_type=replay_state` and `aggregate_id=execution/<execution_id>/<projection>`. Replay can seed from the snapshot, skip earlier events, and fold the remaining stream.
-- Time-based snapshot selection, payload resolution, registered production upcasters for future schema revisions, and business-object projection folds remain tracked by `noetl/noetl#440`.
+- Time-based snapshot selection, payload resolution, registered production upcasters for future schema revisions, and domain-specific business-object reducers remain tracked by `noetl/noetl#440`.
 
 Replay reconstructs state by:
 


### PR DESCRIPTION
## Summary
- record noetl/noetl#499 in the distributed runtime checkpoint
- update replay checksum coverage to include business-object state
- clarify that generic business-object replay is present while domain-specific reducers remain future work

Tracks noetl/noetl#434.