### PR TITLE
docs(architecture): document event-store IPC implementation status

### DIFF
--- a/docs/features/noetl_storage_and_streaming_alignment.md
+++ b/docs/features/noetl_storage_and_streaming_alignment.md
@@ -54,12 +54,53 @@ recovery / scaling story without rebuilding one from scratch.
 | Control plane | `noetl.event` / `noetl.command` / `noetl.execution` | unchanged |
 | Data plane | TempStore (KV / Object / S3 / GCS / DB) | **TempStore restructured into Memory / Disk / Cloud**; NATS Object Store removed |
 
+## Current implementation status
+
+The event-store design prompt describes the long-term three-layer platform:
+event stream, projection/state store, and payload reference/shared cache. The
+current NoETL implementation has shipped the reference-first payload layer and
+the first same-node IPC accelerator pieces, while the fully swappable event
+stream and projection-store adapters remain roadmap work.
+
+Implemented now:
+
+- PostgreSQL remains the authoritative append-only execution event store and
+  projection backend.
+- NATS JetStream is the command-notification transport for workers, not the
+  authoritative event log.
+- Result envelopes carry lightweight `ResultRef` / `TempRef` pointers instead
+  of large inline payloads.
+- `IpcHint` metadata can be attached to a result reference for same-node Arrow
+  IPC access.
+- Cursor workers can serialize claimed frames as Arrow streaming IPC bytes,
+  store the durable payload, and attach a best-effort shared-memory hint.
+- Resolution tries the IPC hint when valid and falls back to the durable
+  reference when the hint is missing, expired, evicted, or not local to the
+  node.
+- Worker metrics expose IPC admission, read hit/miss, fallback, and hit-ratio
+  counters for Phase 3 evidence.
+
+Not yet generalized:
+
+- Event stream adapters for Kafka, Pub/Sub, Event Hubs, Kinesis, and MSK.
+- Projection/state adapters for Firestore, DynamoDB, Cosmos DB, Cassandra,
+  ClickHouse, OpenSearch, and vector databases.
+- Cross-language Rust/Python Arrow shared-memory interoperability as a stable
+  public contract.
+- Cluster-wide shared memory. Tier 1.5 is intentionally same-node only.
+
+The live Phase 3 proof exercised the shipped path end to end: a distributed
+cursor frame produced Arrow IPC bytes, emitted an IPC hint, read via shared
+memory, evicted the hint, then confirmed durable fallback returned the same
+rows. The validation bundle required worker IPC evidence and passed.
+
 ## Storage tiers after alignment
 
 | Tier | Backend | Size band | Scope | Survives pod restart? |
 | --- | --- | --- | --- | --- |
 | `MEMORY` | in-process dict | `< 10 KB` | step | No |
 | `KV` | NATS JetStream KV | `< 1 MB` | execution | Yes (distributed) |
+| **`IPC` / Tier 1.5** | same-node shared memory carrying Arrow IPC bytes | frame-scoped tabular payloads | lease-bound execution accelerator | No; falls back to durable ref |
 | **`DISK` (new)** | local NVMe/SSD cache (PVC) | `1 MB – 10 MB` primary; larger with spill | execution / workflow | Yes (warm-start via `recover_mode=Quiet`) |
 | `S3` | S3 / S3-compatible object store (S3 endpoint) | any | execution / workflow / forever | Yes (durable) |
 | `GCS` | Google Cloud Storage | any | execution / workflow / forever | Yes (durable) |
@@ -76,6 +117,7 @@ functionally with DISK + cloud for every size band.
 ```
 size < 10 KB          → MEMORY
 size < 1 MB           → KV
+cursor frame rows     → durable ref + optional IPC hint
 size >= 1 MB          → DISK
                            ├── in-process: local cache (hot read)
                            └── async spill: cloud tier (durable)
@@ -86,6 +128,11 @@ force_tier=<x>        → <x>
 A `DISK` write is locally cached on the worker and asynchronously
 uploaded to the configured cloud tier so durability matches cloud
 storage semantics while read latency matches local SSD.
+
+The `IPC` tier is not selected as a durable store. It is attached as an
+optional `ipc` hint on a durable result reference. Consumers use it only when
+the hint is local, unexpired, and readable; otherwise they resolve the durable
+reference normally.
 
 ### Disk cache internals (phase 1)
 

--- a/docs/getting-started/architecture.md
+++ b/docs/getting-started/architecture.md
@@ -38,6 +38,26 @@ Central coordination service:
 - Reconstructs workflow state from event table
 - Used by CLIs, UIs, and integrations
 
+### Event Store and Projections
+
+NoETL's current event-sourced runtime uses PostgreSQL as the authoritative
+event and projection store:
+
+- `noetl.event` is the append-only execution history.
+- Projection tables such as executions, commands, stages, frames, and runtime
+  state are rebuildable from events.
+- Replay validation reads the event stream and checks projected runtime state
+  without depending on worker memory.
+- NATS JetStream is used for command notification and worker delivery, not as
+  the authoritative event store in the current implementation.
+
+The broader event-store abstraction described in the architecture roadmap keeps
+the same separation of concerns but allows future deployments to bind the event
+stream to NATS JetStream, Kafka, Pub/Sub, Event Hubs, Kinesis, or MSK, and bind
+projection state to PostgreSQL or cloud-native/document/analytic stores. The DSL
+and playbooks stay backend-neutral; infrastructure configuration selects the
+adapters.
+
 ### Worker Pools
 
 Stateless background executors:
@@ -56,6 +76,29 @@ Message broker for task distribution:
 - Messages contain pointers to Control Plane API for task details
 - Durable subscriptions ensure no task loss
 - Supports multiple worker pools and load balancing
+
+### Result References and Shared Cache
+
+Workers do not push large payloads through the event stream. Task outcomes use a
+reference-first model:
+
+- Small values may be inline.
+- Larger results are stored behind a `ResultRef` / `TempRef` with a logical
+  `noetl://...` URI.
+- The durable reference remains the source of truth and can resolve from KV,
+  disk, S3-compatible storage, GCS, or PostgreSQL depending on tier and runtime
+  configuration.
+- Tabular cursor-frame payloads can be serialized as Apache Arrow IPC
+  (`application/vnd.apache.arrow.stream`).
+- Co-located producer/consumer workers can attach to an optional same-node
+  shared-memory `ipc` hint on the reference. This is Tier 1.5: a best-effort
+  acceleration path, not authoritative state.
+- If the IPC hint is missing, expired, evicted, or belongs to a different node,
+  resolution falls back to the durable `ResultRef`.
+
+The live Phase 3 IPC proof validated this path end to end: a cursor frame wrote
+Arrow IPC bytes, emitted an IPC hint, read via shared memory, evicted the hint,
+then successfully read the same rows through durable fallback.
 
 ### Catalog & Credentials
 
@@ -106,6 +149,9 @@ Connectors for external systems:
 7. **Workers** execute steps and report events to Control Plane API
 8. **Control Plane** stores events in PostgreSQL `noetl.event` table
 9. **Control Plane** monitors events to determine next steps in workflow
+10. **Large results** are stored by reference; events carry ResultRef metadata
+11. **Cursor frames** may attach an optional Arrow IPC shared-memory hint for
+    same-node consumers, while durable storage remains the fallback
 
 ## Database Schema
 

--- a/docs/reference/result_storage.md
+++ b/docs/reference/result_storage.md
@@ -56,7 +56,7 @@ The event log stores: metadata + ResultRef + extracted fields + preview.
 {
   "kind": "result_ref",
   "ref": "noetl://execution/123/step/fetch/task/fetch_page/run/abc123",
-  "store": "nats_kv|object-store|gcs|postgres",
+  "store": "memory|kv|disk|s3|gcs|db|eventlog",
   "scope": "step|execution|workflow|permanent",
   "expires_at": "2026-02-01T13:00:00Z",
   "meta": {
@@ -64,6 +64,17 @@ The event log stores: metadata + ResultRef + extracted fields + preview.
     "bytes": 52480,
     "sha256": "abc123...",
     "compression": "gzip"
+  },
+  "ipc": {
+    "kind": "arrow_ipc",
+    "shm_name": "noetl_frame_e2606e14_8918ba44",
+    "schema_digest": "ca41f6...",
+    "byte_length": 448,
+    "row_count": 2,
+    "producer": "noetl-worker-...",
+    "node_id": "noetl-control-plane",
+    "lease_expires_at": "2026-05-21T05:08:09Z",
+    "media_type": "application/vnd.apache.arrow.stream"
   },
   "extracted": {
     "has_more": true,
@@ -81,6 +92,8 @@ The event log stores: metadata + ResultRef + extracted fields + preview.
 ### 2.2 Logical vs physical addressing
 - `ref` is a **logical URI** (`noetl://...`) stable across backends.
 - Physical details (bucket/key/object/table range) live in `meta` and/or a server mapping.
+- `ipc` is an optional same-node acceleration hint. It is never the source of
+  truth; the durable `ref` must remain resolvable without it.
 
 ---
 
@@ -94,7 +107,31 @@ Use for:
 Recommended ResultRef meta:
 - `meta.bucket`, `meta.key`
 
-### 3.2 S3-compatible object storage (medium and large)
+### 3.2 Arrow IPC shared memory (same-node accelerator)
+Use for:
+- cursor frame rows
+- tabular payloads that a co-located worker may consume immediately
+- producer-side map/reduce style fan-out where durable fallback is still required
+
+This is Tier 1.5 in the event-store design. The payload is serialized as
+Apache Arrow streaming IPC and may be written into a lease-bound shared-memory
+segment. The `ResultRef` carries an optional `ipc` hint with the shared-memory
+name, Arrow schema digest, byte length, row count, producer identity, node
+identity, lease expiration, and media type.
+
+Resolution policy:
+
+1. Validate the hint is present, unexpired, and local to the current node.
+2. Attempt to attach and read Arrow IPC bytes from shared memory.
+3. If the IPC read fails, increment a miss counter and fall back to the durable `ref`.
+4. Decode Arrow IPC bytes into rows for consumers that request materialized payloads.
+
+The implementation records metrics for admission attempts/success/failures,
+read attempts/hits/misses, fallback reads, and hit ratio. A live Phase 3 proof
+validated an IPC read, forced eviction of the hint, and then validated durable
+fallback returned identical rows.
+
+### 3.3 S3-compatible object storage (medium and large)
 Use for:
 - multi-MB payloads
 - page payloads and streamed chunks that should not live in KV
@@ -110,7 +147,7 @@ Guidance:
   auto-remapped to `store: "disk"` (local SSD cache + async cloud
   spill). See [Storage and Streaming Alignment with RisingWave](../features/noetl_storage_and_streaming_alignment.md).
 
-### 3.3 Google Cloud Storage (large / durable)
+### 3.4 Google Cloud Storage (large / durable)
 Use for:
 - large payloads
 - longer retention
@@ -119,7 +156,7 @@ Use for:
 Recommended ResultRef meta:
 - `meta.bucket`, `meta.object` (or `meta.uri`)
 
-### 3.4 Postgres (queryable)
+### 3.5 Postgres (queryable)
 Use for:
 - queryable intermediate tables (facts, audit rows)
 - projections and indices for refs
@@ -141,6 +178,10 @@ A runtime SHOULD support `store.kind: auto` with size-aware selection:
 - else → GCS (or Postgres table when queryability is required)
 
 Thresholds are runtime config, but the **tier model** is stable.
+
+Arrow IPC shared memory is not chosen as the durable store in `store.kind`.
+It is attached opportunistically to a durable reference by runtime features such
+as cursor frame capture.
 
 ---
 


### PR DESCRIPTION
## Summary

- update the high-level architecture page with the current event-store/projection split
- document that PostgreSQL remains authoritative today while NATS JetStream is command transport
- add the implemented ResultRef + Arrow IPC Tier 1.5 shared-memory status and limitations
- update result-storage reference with the optional `ipc` hint shape and durable fallback semantics

## Validation

- `npm run typecheck`
- `npm run build`
- live NoETL Phase 3 IPC proof completed before this docs update:
  - distributed cursor-frame execution `631434223991128897`
  - Arrow IPC hint present
  - IPC read matched expected rows
  - IPC hint evicted
  - durable fallback read matched expected rows
  - worker IPC metrics evidence passed
  - replay validation bundle passed with `--require-worker-ipc-phase3`
