### PR TITLE
docs(cli): document context init/update/port-forward, global --context flag, exit code 77

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -84,11 +84,22 @@ The `noetl run` command accepts multiple reference formats:
 
 ### 3. Context Management
 
-Contexts store server URLs and default runtime preferences:
+Contexts store server URLs, default runtime preferences, Auth0
+application metadata, and (optionally) Kubernetes connection fields
+for the managed port-forward daemon.
 
 ```bash
-# Add a context
+# Add a context from CLI flags
 noetl context add local-dev --server-url=http://localhost:8082 --runtime=local
+
+# Bootstrap a context by reading the gateway's runtime contract
+# (discovers Auth0 client_id/redirect_uri/audience for you)
+noetl context init gke-prod --from-gateway https://gateway.mestumre.dev --set-current
+
+# Patch fields in place (no delete + re-add dance)
+noetl context update gke-prod --auth0-client-id=NewClientIdAfterRotation
+noetl context update gke-prod --kube-context=gke_demo_us-central1_noetl-cluster \
+                              --kube-namespace=noetl
 
 # Set runtime for current context
 noetl context set-runtime local
@@ -100,34 +111,90 @@ noetl context current
 
 # Switch contexts
 noetl context use prod
+
+# Manage kubectl port-forward as a daemon for a context that has
+# kube_* fields set
+noetl context port-forward gke-pf --detach    # background, PID file
+noetl context port-forward gke-pf --status    # PID + liveness
+noetl context port-forward gke-pf --stop      # kill + cleanup
 ```
 
-Gateway + Auth0 context example:
+#### Gateway + Auth0: one-command bootstrap
+
+`noetl context init --from-gateway` reads the gateway's
+`GET /api/runtime/contract`, parses the `auth0` block, prints a
+confirmation table, and writes the context — so you don't have to
+look up Auth0 application IDs in the Auth0 dashboard.
 
 ```bash
-noetl context add gke-prod \
-  --server-url https://gateway.mestumre.dev \
+# Discover + write context in one command
+noetl context init gke-prod \
+  --from-gateway https://gateway.mestumre.dev \
   --runtime distributed \
-  --auth0-domain mestumre-development.us.auth0.com \
-  --auth0-client-id '<AUTH0_CLIENT_ID>' \
-  --auth0-redirect-uri 'https://mestumre.dev/login' \
   --set-current
 
-noetl auth login --auth0-callback-url 'https://mestumre.dev/login#id_token=...'
+# Then log in (caches session token onto the context)
+noetl auth login --browser-pkce
 
 # gcloud-style browser/device login (no token copy)
 noetl auth login --browser
 
-# gcloud-style browser PKCE login with localhost callback
-noetl auth login --browser-pkce
-# optional login hint and callback port override
+# Optional login hint and callback port override
 noetl auth login --browser-pkce --auth0 user@example.com --pkce-port 8765
 ```
 
-PKCE notes:
+If the gateway image is older than v2.10 (no Auth0 exposure on the
+runtime contract), fall back to `noetl context add` with the Auth0
+fields supplied directly, or use `noetl context update` after
+`context init` to fill in what the contract didn't include.
+
+#### PKCE flow notes
+
 - Default callback URI is `http://127.0.0.1:8765/callback`.
-- Override callback URI using `--auth0-redirect-uri`; it must use `localhost` or `127.0.0.1`.
-- Auth0 application must allow the callback URI in allowed callback URLs.
+- Override callback URI using `--auth0-redirect-uri`; it must use
+  `localhost` or `127.0.0.1`.
+- The Auth0 application must allow the callback URI in **Allowed
+  Callback URLs**. The CLI prints the Auth0 dashboard URL for the
+  application as part of its PKCE pre-flight so you can verify
+  this before the browser opens. If Auth0 rejects with "Callback
+  URL mismatch", add the URI shown in the pre-flight and retry.
+
+#### Per-command context override
+
+For a single command against a non-current context, use the global
+`--context <name>` flag — mirrors `kubectl --context` and
+`gcloud --account`:
+
+```bash
+noetl --context gke-prod catalog list Playbook
+noetl --context gke-pf   register credential -f duffel.json
+noetl --context smoke    exec ./playbooks/foo.yaml
+```
+
+The current context is unchanged.
+
+#### After login: no need to `export NOETL_SESSION_TOKEN`
+
+A successful `noetl auth login` caches the gateway session token
+directly onto the context file (`~/.noetl/config.toml`). Subsequent
+CLI calls read it from there automatically. The
+`export NOETL_SESSION_TOKEN=...` hint printed after login is for
+**other tools** (curl, scripts) that read the env var — not for the
+CLI itself.
+
+#### Exit code 77 — gateway session expired
+
+When the gateway returns 401 to a request that used a cached session
+token, the CLI exits with code **77** and prints a re-login hint.
+Scripts can branch on the exit code:
+
+```bash
+noetl --context gke-prod catalog list Playbook || code=$?
+if [[ "${code:-0}" -eq 77 ]]; then
+    noetl auth login --browser-pkce --context gke-prod
+    noetl --context gke-prod catalog list Playbook
+fi
+```
 
 **Common Context Workflows:**
 
@@ -429,37 +496,61 @@ noetl context set-runtime distributed
 noetl context set-runtime auto
 ```
 
-**Context Configuration File**: `~/.noetl/config.json`
+**Context Configuration File**: `~/.noetl/config.toml`
 
-```json
-{
-  "current_context": "local-dev",
-  "contexts": {
-    "local-dev": {
-      "server_url": "http://localhost:8082",
-      "runtime": "local"
-    },
-    "prod": {
-      "server_url": "https://noetl.prod.example.com",
-      "runtime": "distributed"
-    }
-  }
-}
+```toml
+current_context = "local-dev"
+
+[contexts.local-dev]
+server_url = "http://localhost:8082"
+runtime    = "local"
+
+[contexts.prod]
+server_url = "https://noetl.prod.example.com"
+runtime    = "distributed"
+
+[contexts.gke-prod]
+server_url             = "https://gateway.mestumre.dev"
+runtime                = "distributed"
+auth0_domain           = "mestumre-development.us.auth0.com"
+auth0_client_id        = "<client-id>"
+auth0_redirect_uri     = "https://mestumre.dev/login"
+gateway_session_token  = "<cached-after-noetl-auth-login>"
+
+[contexts.gke-pf]
+server_url        = "http://127.0.0.1:18082"
+runtime           = "distributed"
+kube_context      = "gke_demo_us-central1_noetl-cluster"
+kube_namespace    = "noetl"
+kube_service      = "noetl"   # default
+kube_remote_port  = 8082      # default
 ```
+
+Additionally, the managed port-forward daemon writes PID files to
+`~/.noetl/port-forwards/<context>.pid` — one per context.
 
 ## Command Categories
 
 | Category | Commands | Purpose |
 |----------|----------|---------|
-| **Execution** | `run` | Execute playbooks (local or distributed) |
-| **Context** | `context add/use/list/set-runtime` | Manage execution contexts |
+| **Execution** | `run`, `exec` | Execute playbooks (local or distributed) |
+| **Context** | `context add/init/update/use/list/current/delete/set-runtime/port-forward` | Manage execution contexts and managed kubectl tunnels |
+| **Auth** | `auth login` (`--browser-pkce`, `--browser`, `--password`, callback URL, raw token) | Authenticate against the gateway |
 | **Server** | `server start/stop` | Manage server process |
 | **Worker** | `worker start/stop` | Manage worker process |
 | **Register** | `register playbook/credential` | Add resources to catalog |
-| **Catalog** | `catalog list/get` | Query registered resources |
-| **K8s** | `k8s deploy/redeploy/remove` | Kubernetes operations |
+| **Catalog** | `catalog list/get/register` | Query registered resources |
+| **K8s** | `k8s deploy/redeploy/remove/reset` | Kubernetes operations |
 | **Database** | `db init/validate` | Database management |
-| **IaP** | `iap init/state/sync` | Infrastructure as Playbook |
+| **IaP** | `iap init/plan/apply/state/sync/workspace` | Infrastructure as Playbook |
+
+**Global flags**:
+
+| Flag | Purpose |
+|---|---|
+| `--context <NAME>` | Run one command using the named context, without changing the current one. |
+| `--gateway` | Force gateway-proxy mode. |
+| `--session-token <TOKEN>` | Override the cached session token for one command. |
 
 ## Quick Start Examples
 

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -17,16 +17,23 @@ NoETL provides a unified command-line interface for executing playbooks with two
 
 The main command is `noetl`, which provides:
 
-- `noetl run` - Execute playbooks (local or distributed)
+- `noetl run` / `noetl exec` - Execute playbooks (local or distributed)
 - `noetl status` - Check execution status
 - `noetl cancel` - Cancel running executions
-- `noetl context` - Manage execution contexts and runtime preferences
+- `noetl context` - Manage execution contexts, Auth0 settings, managed kubectl tunnels
+- `noetl auth login` - Authenticate against the gateway (browser PKCE, password grant, callback URL, raw token)
 - `noetl server` - Manage NoETL server process
 - `noetl worker` - Manage worker processes
 - `noetl iap` - Infrastructure as Playbook commands
 - `noetl db` - Database management commands
 - `noetl k8s` - Kubernetes deployment commands
 - `noetl build` - Build Podman images
+
+Global flags (available on every subcommand):
+
+- `--context <NAME>` - Run one command using the named context, without changing the current one.
+- `--gateway` - Force gateway-proxy mode.
+- `--session-token <TOKEN>` - Override the cached session token for one command.
 
 ## Quick Start
 
@@ -146,82 +153,240 @@ noetl context current
 
 ## Context Management
 
-Contexts store server URLs and default runtime preferences:
+Contexts store server URLs, default runtime preferences, Auth0
+application metadata, and (optionally) Kubernetes connection fields
+for the managed port-forward daemon. The CLI exposes five
+write-side commands plus the read-side `list / current / use /
+delete / set-runtime`:
+
+| Subcommand | Purpose |
+|---|---|
+| `context add` | Create a context from CLI flags. |
+| `context init --from-gateway` | Bootstrap from the gateway's runtime contract (discovers Auth0 fields). |
+| `context update` | Patch fields in place — no delete + re-add dance. |
+| `context port-forward` | Start / stop / status a managed `kubectl port-forward` daemon. |
+| `context set-runtime` | Change the default runtime on the current context. |
+
+### Quick reference
 
 ```bash
-# Add a new context
+# Add a new context from CLI flags
 noetl context add local-dev \
   --server-url=http://localhost:8082 \
   --runtime=local \
   --set-current
 
-# Add production context
-noetl context add prod \
-  --server-url=https://noetl.prod.example.com \
-  --runtime=distributed
+# Bootstrap a gateway context — reads gateway /api/runtime/contract
+noetl context init gke-prod --from-gateway https://gateway.mestumre.dev --set-current
 
-# List all contexts
+# Patch any field after creation (Auth0 rotation, kube fields, runtime change)
+noetl context update gke-prod --auth0-client-id=NewClientIdAfterRotation
+noetl context update gke-prod --kube-context=gke_demo_us-central1_noetl-cluster \
+                              --kube-namespace=noetl
+
+# List / inspect / switch / delete
 noetl context list
-
-# Switch context
-noetl context use prod
-
-# View current context
 noetl context current
-
-# Change runtime for current context
-noetl context set-runtime local
-
-# Delete a context
+noetl context use prod
 noetl context delete old-env
+noetl context set-runtime local
 ```
+
+### `noetl --context <name>` per-command override
+
+For a single command against a non-current context, use the global
+`--context <name>` flag (mirrors `kubectl --context` and
+`gcloud --account`). The current context is unchanged:
+
+```bash
+noetl --context gke-prod catalog list Playbook
+noetl --context gke-pf   register credential -f duffel.json
+noetl --context smoke    exec ./playbooks/foo.yaml
+```
+
+### `noetl context init --from-gateway`
+
+Discover Auth0 fields from the gateway in one command:
+
+```bash
+noetl context init <name> --from-gateway <gateway-url> [flags]
+```
+
+The CLI fetches `GET <gateway-url>/api/runtime/contract`, parses the
+`auth0` block (`domain`, `client_id`, `redirect_uri`, `audience`),
+prints what it's about to write, prompts for confirmation, and
+writes the context. Use `--yes` (alias `--non-interactive`) to skip
+the prompt in CI:
+
+```bash
+noetl context init gke-prod \
+  --from-gateway https://gateway.mestumre.dev \
+  --runtime distributed \
+  --set-current
+
+# CI variant
+noetl context init gke-prod \
+  --from-gateway https://gateway.mestumre.dev \
+  --yes
+```
+
+If the gateway doesn't expose an `auth0` block (older image or
+non-Auth0 deployment), the CLI writes `server_url` only and prints
+a follow-up `noetl context update` invocation.
+
+### `noetl context update`
+
+Patch any field on an existing context in place. Every flag is
+optional; omitted fields are preserved. Empty string clears Auth0 /
+kube string fields; `--kube-remote-port=0` clears back to the
+default of `8082`:
+
+```bash
+# Rotate Auth0 client_id without dropping the cached session token
+noetl context update gke-prod --auth0-client-id=NewClientIdAfterRotation
+
+# Point an existing port-forward context at a different local port
+noetl context update gke-pf --server-url=http://127.0.0.1:18083
+
+# Add kube fields so context port-forward will work
+noetl context update gke-prod \
+  --kube-context=gke_demo_us-central1_noetl-cluster \
+  --kube-namespace=noetl
+
+# Clear an audience that was set by mistake
+noetl context update gke-prod --auth0-audience=""
+```
+
+The cached `gateway_session_token` is **not** touched by `context
+update`.
+
+### `noetl context port-forward`
+
+Managed `kubectl port-forward` daemon for a context that has
+`kube_context` + `kube_namespace` set. The local port comes from
+the context's `server_url` (must be a loopback URL like
+`http://127.0.0.1:18082`).
+
+```bash
+# Foreground — exits on Ctrl-C
+noetl context port-forward gke-pf
+
+# Background daemon — writes ~/.noetl/port-forwards/gke-pf.pid
+noetl context port-forward gke-pf --detach
+
+# Liveness check
+noetl context port-forward gke-pf --status
+
+# SIGTERM (500 ms grace) → SIGKILL → PID file cleanup
+noetl context port-forward gke-pf --stop
+```
+
+Before spawning kubectl, the CLI probes the local port with a
+`TcpListener::bind`. If the port is already in use, the CLI exits
+with a diagnostic pointing to `lsof`, `fuser`, and
+`pkill -f 'port-forward svc/noetl'` so you can identify the culprit.
 
 ### Gateway Context + Auth0 Login
 
-Use a gateway context when you want authenticated access through `https://gateway.mestumre.dev` and no direct API port-forwarding.
+For deployments behind a gateway (e.g. `https://gateway.mestumre.dev`):
 
 ```bash
-# Create or update gateway context
-noetl context add gke-prod \
-  --server-url https://gateway.mestumre.dev \
-  --runtime distributed \
-  --auth0-domain mestumre-development.us.auth0.com \
-  --auth0-client-id '<AUTH0_CLIENT_ID>' \
-  --auth0-redirect-uri 'https://mestumre.dev/login' \
-  --set-current
+# Modern path — discover Auth0 fields from the gateway
+noetl context init gke-prod --from-gateway https://gateway.mestumre.dev --set-current
 
-# Exchange Auth0 callback token for gateway session token (cached in context)
-noetl auth login --auth0-callback-url 'https://mestumre.dev/login#id_token=...'
+# Browser PKCE login (recommended interactive flow)
+noetl auth login --browser-pkce
 
 # gcloud-style browser/device flow (no callback copy/paste)
 noetl auth login --browser
 
-# gcloud-style browser PKCE flow with localhost callback
-noetl auth login --browser-pkce
-# optional login hint and callback port override
+# Optional login hint and callback port override
 noetl auth login --browser-pkce --auth0 user@example.com --pkce-port 8765
+
+# Paste full Auth0 callback URL (legacy flow)
+noetl auth login --auth0-callback-url 'https://mestumre.dev/login#id_token=...'
 ```
 
-Then run authenticated commands through gateway:
+Then run authenticated commands through the gateway:
 
 ```bash
-noetl --gateway catalog register tests/fixtures/playbooks/quantum_cudaq/quantum_cudaq.yaml
-noetl --gateway exec tests/quantum/cudaq_ai_pipeline -r distributed
+noetl --context gke-prod catalog register tests/fixtures/playbooks/quantum_cudaq/quantum_cudaq.yaml
+noetl --context gke-prod exec tests/quantum/cudaq_ai_pipeline -r distributed
 ```
 
-If your context URL is already a gateway URL (`gateway.*`), proxy mode is auto-detected; `--gateway` remains available as an explicit override.
+If your context URL is already a gateway URL (`gateway.*`),
+gateway-proxy mode is auto-detected; `--gateway` remains available
+as an explicit override.
 
-For password grant without storing secret in local config, pass it per-command or via ephemeral env var:
+For password grant without storing the secret in local config, pass
+it per-command or via ephemeral env var:
 
 ```bash
 noetl auth login --auth0 user@example.com --password --auth0-client-secret "$AUTH0_CLIENT_SECRET"
 NOETL_AUTH0_CLIENT_SECRET="$AUTH0_CLIENT_SECRET" noetl auth login --auth0 user@example.com --password
 ```
 
-PKCE callback details:
+#### PKCE callback details
+
 - Default callback URI: `http://127.0.0.1:8765/callback`.
-- Override with `--auth0-redirect-uri` (must be `localhost` or `127.0.0.1`).
-- Ensure the callback URI is configured in your Auth0 application's allowed callback URLs.
+- Override with `--auth0-redirect-uri` (must be `localhost` or
+  `127.0.0.1`).
+- The Auth0 application must allow the callback URI in **Allowed
+  Callback URLs**. The CLI prints a pre-flight notice with the
+  exact URI and the Auth0 dashboard URL for the application, so
+  you can verify the allowlist before the browser opens. If
+  authentication hangs and the browser shows "Callback URL
+  mismatch", add the URI shown in the pre-flight and retry.
+
+#### After login: the session token is cached on the context
+
+A successful `noetl auth login` writes the gateway session token
+directly onto the context file (`~/.noetl/config.toml`):
+
+```
+Gateway login successful.
+  Gateway: https://gateway.mestumre.dev
+  User:    you@example.com
+  Token:   69dd6f...2bc6
+  Saved:   context 'gke-prod'
+
+Use this session for CLI calls:
+  export NOETL_SESSION_TOKEN='69dd6f8a7621ca3cd1e8924460842bc6'
+```
+
+Subsequent CLI calls against that context read the token from the
+file automatically — you do **not** need to run the printed
+`export` line for CLI usage. The env var is only useful for
+external tools that read it (curl, ad-hoc scripts), or for one-off
+commands where you don't want the token persisted.
+
+Verify with a one-shot command:
+
+```bash
+noetl --context gke-prod catalog list Playbook
+```
+
+A list of playbooks means you're authenticated end-to-end.
+
+#### Exit code 77 — gateway session expired
+
+When any CLI command receives a 401 from the gateway using a cached
+session token, the CLI exits with code **77** and prints:
+
+```
+Gateway returned 401 (session expired) for context 'gke-prod'.
+  Refresh the session token:  noetl auth login --browser-pkce
+```
+
+Scripts can branch on the exit code to auto-trigger a re-login:
+
+```bash
+noetl --context gke-prod catalog list Playbook || code=$?
+if [[ "${code:-0}" -eq 77 ]]; then
+    noetl auth login --browser-pkce --context gke-prod
+    noetl --context gke-prod catalog list Playbook
+fi
+```
 
 ### Common Context Workflows
 

--- a/docs/operations/notes.md
+++ b/docs/operations/notes.md
@@ -73,24 +73,52 @@ noetl run automation/gcp_gke/noetl_gke_fresh_stack.yaml --runtime local \
   --set bootstrap_gateway_auth=true
 ```
 
-## 4) Login and export session token
+## 4) Login
 
 ```bash
-noetl auth login --context gke-prod --auth0 you@example.com
-# paste full Auth0 callback URL when prompted (or valid JWT token)
-export NOETL_SESSION_TOKEN='<session-token-from-success-output>'
+# Recommended — interactive browser PKCE
+noetl auth login --browser-pkce --context gke-prod
+
+# Or paste a full Auth0 callback URL
+noetl auth login --context gke-prod --auth0-callback-url 'https://mestumre.dev/login#id_token=...'
 ```
+
+A successful login caches the gateway session token onto the
+context file (`~/.noetl/config.toml`); subsequent CLI calls against
+that context read it from there automatically. The
+`export NOETL_SESSION_TOKEN=...` hint printed after login is for
+**other tools** that read the env var (the curl examples in
+section 9 below, for instance) — not for the CLI itself.
 
 Notes:
 
 - A short opaque token is not a JWT and will fail with `Invalid JWT format`.
-- Use the full callback URL (`...#id_token=...`) or valid JWT form.
+- Use the full callback URL (`...#id_token=...`) or a valid JWT in the
+  `--auth0-token` / `--auth0-callback-url` modes.
+- Browser PKCE first-time setup requires the callback URI
+  (`http://127.0.0.1:8765/callback`) to be in the Auth0 application's
+  **Allowed Callback URLs**. The CLI prints the Auth0 dashboard URL
+  for the application as part of its PKCE pre-flight so you can verify
+  the allowlist before the browser opens.
+- If a later CLI call against `gke-prod` exits with code **77**, the
+  session expired — re-run the login above.
+
+For curl-based DB queries against the gateway (section 9 below),
+export the token from the context after login:
+
+```bash
+# Extract the cached gateway_session_token from the context file
+export NOETL_SESSION_TOKEN=$(awk -F'"' '/^gateway_session_token/ {print $2}' \
+  ~/.noetl/config.toml | head -n1)
+```
 
 ## 5) Verify and use context
 
 ```bash
 noetl context list
-noetl context use gke-prod
+noetl context use gke-prod                         # persistent switch
+# or, per-command without changing the current context:
+noetl --context gke-prod catalog list Playbook
 ```
 
 ## 6) Register playbooks


### PR DESCRIPTION
## Summary

Refresh the CLI docs to match the surface shipped in noetl/cli v2.15.0 - v2.17.0 (PRs noetl/cli#13, #14, #16, #17):

- New \`noetl context init --from-gateway <url>\` — bootstrap a context by reading the gateway's \`GET /api/runtime/contract\` \`auth0\` block, with operator confirmation.
- New \`noetl context update\` — patch fields in place; no delete + re-add dance, no dropped session token.
- New \`noetl context port-forward <name>\` — managed \`kubectl port-forward\` daemon with \`--detach\` / \`--stop\` / \`--status\`, PID file at \`~/.noetl/port-forwards/<ctx>.pid\`, \`TcpListener\` bind probe so stray kubectl from another shell fails fast instead of leaving an orphan PID file.
- New global \`noetl --context <name>\` flag — per-command override, mirrors \`kubectl --context\` and \`gcloud --account\`.
- New exit code **77** for gateway session expired so scripts can branch without parsing stderr.
- \`auth login --browser-pkce\` pre-flight now prints the Auth0 dashboard URL for the application so operators can verify the callback URI is allowlisted before the browser opens.

Also corrects two pieces of long-standing stale advice:

1. \`Context Configuration File: ~/.noetl/config.json\` — the file is actually TOML (\`~/.noetl/config.toml\`). Realistic example layout added, including \`auth0_*\` and \`kube_*\` fields.
2. \`export NOETL_SESSION_TOKEN=...\` — the CLI does **not** need this for its own calls (it reads from the context file). The export hint is for other tools (curl, ad-hoc scripts).

## Pages touched

| Page | Change |
|---|---|
| \`docs/cli/index.md\` | Modern context workflow, new commands, global flags, exit code, config file format fix, expanded command-categories table. |
| \`docs/cli/usage.md\` | Same surface in the Reference page; PKCE pre-flight notes updated; examples switched to \`--context <name>\` (\`--gateway\` still documented as a fallback). |
| \`docs/operations/notes.md\` | Section 4 (\"Login and export session token\") rewritten to reflect token caching on the context file; section now shows the PKCE flow first and provides a curl-only fallback (read the cached token out of \`~/.noetl/config.toml\`) for the postgres examples later in the page. Mentions exit code 77 and the PKCE dashboard URL hint. |

Other pages that mention CLI patterns (\`docs/getting-started/quickstart.md\`, \`docs/development/automation_playbooks.md\`, \`docs/gui/custom-ui-gateway.md\`, \`docs/tutorials/09-internet-postgres-gcs.md\`, \`docs/cli/local_execution.md\`) were inspected — they use surfaces that didn't change, so they're left alone.

## Test plan

- [ ] \`yarn build\` (Docusaurus) — no broken links.
- [ ] Spot-check the three pages on the staging deploy that the new commands match the actual help output (\`noetl context --help\`, \`noetl auth login --help\`).
- [ ] Confirm the awk extractor for \`gateway_session_token\` in \`operations/notes.md\` works against an actual \`~/.noetl/config.toml\` (no quoting surprises).

## Related

- Wiki coverage shipped in parallel at https://github.com/noetl/cli/wiki (Connecting-to-a-cluster, context-init, context-update, context-port-forward, global-context-flag, exit-codes, auth-login pages).
- noetl/cli releases: v2.15.0 (PR #13), v2.15.0 (PR #14 - port-forward), v2.16.0 (PR #16 - from-gateway), v2.17.0 (PR #17 - port-conflict probe + global --context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)