### PR TITLE
docs(cli): correct config file — ~/.noetl/config.yaml (was .toml)

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -176,7 +176,7 @@ The current context is unchanged.
 #### After login: no need to `export NOETL_SESSION_TOKEN`
 
 A successful `noetl auth login` caches the gateway session token
-directly onto the context file (`~/.noetl/config.toml`). Subsequent
+directly onto the context file (`~/.noetl/config.yaml`). Subsequent
 CLI calls read it from there automatically. The
 `export NOETL_SESSION_TOKEN=...` hint printed after login is for
 **other tools** (curl, scripts) that read the env var — not for the
@@ -496,34 +496,47 @@ noetl context set-runtime distributed
 noetl context set-runtime auto
 ```
 
-**Context Configuration File**: `~/.noetl/config.toml`
+**Context Configuration File**: `~/.noetl/config.yaml`
 
-```toml
-current_context = "local-dev"
+The CLI uses `--<flag>` names for input (e.g. `--auth0-domain`), but
+the serialized form on disk uses snake_case with a `gateway_`
+prefix for the auth0 / session fields. Inspect with
+`noetl context current` or `noetl context list` rather than reading
+the file by hand.
 
-[contexts.local-dev]
-server_url = "http://localhost:8082"
-runtime    = "local"
+```yaml
+current_context: local-dev
 
-[contexts.prod]
-server_url = "https://noetl.prod.example.com"
-runtime    = "distributed"
+contexts:
+  local-dev:
+    server_url: http://localhost:8082
+    runtime: local
 
-[contexts.gke-prod]
-server_url             = "https://gateway.mestumre.dev"
-runtime                = "distributed"
-auth0_domain           = "mestumre-development.us.auth0.com"
-auth0_client_id        = "<client-id>"
-auth0_redirect_uri     = "https://mestumre.dev/login"
-gateway_session_token  = "<cached-after-noetl-auth-login>"
+  prod:
+    server_url: https://noetl.prod.example.com
+    runtime: distributed
 
-[contexts.gke-pf]
-server_url        = "http://127.0.0.1:18082"
-runtime           = "distributed"
-kube_context      = "gke_demo_us-central1_noetl-cluster"
-kube_namespace    = "noetl"
-kube_service      = "noetl"   # default
-kube_remote_port  = 8082      # default
+  gke-prod:
+    server_url: https://gateway.mestumre.dev
+    runtime: distributed
+    gateway_session_token: <cached-after-noetl-auth-login>
+    gateway_auth0_domain: mestumre-development.us.auth0.com
+    gateway_auth0_client_id: <client-id>
+    gateway_auth0_redirect_uri: https://mestumre.dev/login
+    gateway_auth0_audience: null
+    gateway_auth0_client_secret: null
+    kube_context: null
+    kube_namespace: null
+    kube_service: null
+    kube_remote_port: null
+
+  gke-pf:
+    server_url: http://127.0.0.1:18082
+    runtime: distributed
+    kube_context: gke_demo_us-central1_noetl-cluster
+    kube_namespace: noetl
+    kube_service: noetl           # default
+    kube_remote_port: 8082        # default
 ```
 
 Additionally, the managed port-forward daemon writes PID files to

--- a/docs/cli/usage.md
+++ b/docs/cli/usage.md
@@ -341,7 +341,7 @@ NOETL_AUTH0_CLIENT_SECRET="$AUTH0_CLIENT_SECRET" noetl auth login --auth0 user@e
 #### After login: the session token is cached on the context
 
 A successful `noetl auth login` writes the gateway session token
-directly onto the context file (`~/.noetl/config.toml`):
+directly onto the context file (`~/.noetl/config.yaml`):
 
 ```
 Gateway login successful.

--- a/docs/operations/notes.md
+++ b/docs/operations/notes.md
@@ -84,7 +84,7 @@ noetl auth login --context gke-prod --auth0-callback-url 'https://mestumre.dev/l
 ```
 
 A successful login caches the gateway session token onto the
-context file (`~/.noetl/config.toml`); subsequent CLI calls against
+context file (`~/.noetl/config.yaml`); subsequent CLI calls against
 that context read it from there automatically. The
 `export NOETL_SESSION_TOKEN=...` hint printed after login is for
 **other tools** that read the env var (the curl examples in
@@ -104,12 +104,23 @@ Notes:
   session expired — re-run the login above.
 
 For curl-based DB queries against the gateway (section 9 below),
-export the token from the context after login:
+export the token from the context after login.  The CLI stores its
+config as YAML at `~/.noetl/config.yaml`; pick whichever extractor
+fits the tools you have:
 
 ```bash
-# Extract the cached gateway_session_token from the context file
-export NOETL_SESSION_TOKEN=$(awk -F'"' '/^gateway_session_token/ {print $2}' \
-  ~/.noetl/config.toml | head -n1)
+# yq (preferred — reliable on YAML)
+export NOETL_SESSION_TOKEN=$(yq -r '.contexts."gke-prod".gateway_session_token' \
+  ~/.noetl/config.yaml)
+
+# awk fallback (no yq required) — pulls the gateway_session_token
+# from inside the gke-prod block.  Works because the serialized form
+# is unquoted scalars and the contexts map is top-level.
+export NOETL_SESSION_TOKEN=$(awk '
+  /^  gke-prod:/{flag=1; next}
+  /^  [a-z][a-z0-9_-]*:$/{flag=0}
+  flag && /gateway_session_token:/{print $2; exit}
+' ~/.noetl/config.yaml)
 ```
 
 ## 5) Verify and use context


### PR DESCRIPTION
## Summary

Follow-up to noetl/docs#170 — corrects the CLI config file path and example layout.

The CLI persists context state as YAML at `~/.noetl/config.yaml` (per `cli/src/config.rs:105`), not TOML. PR #170 got the path wrong everywhere and included a TOML example block that doesn't match what `noetl context add` actually writes to disk.

## What changed

- All `~/.noetl/config.toml` references → `~/.noetl/config.yaml` across `docs/cli/index.md`, `docs/cli/usage.md`, `docs/operations/notes.md`.
- Replaced the TOML example layout in `docs/cli/index.md` with the actual YAML serialization shape, including the `gateway_` prefix the on-disk form uses (`gateway_session_token`, `gateway_auth0_domain`, `gateway_auth0_client_id`, `gateway_auth0_redirect_uri`). The flag names used by `noetl context add` etc. remain `--auth0-domain` / `--auth0-client-id`; only the serialized form is bracketed by `gateway_`.
- Added a note pointing operators at `noetl context current` / `noetl context list` rather than reading the file by hand.
- Fixed the `operations/notes.md` section 4 token extractor:
  - The awk-based version now scopes to the `gke-prod:` block and matches unquoted YAML scalars (not TOML quoted values).
  - Added a `yq` variant as the preferred form when yq is installed.

## How it surfaced

Caught during the Duffel MCP smoke test against GKE — the previous extractor produced an empty token and a 404 from the gateway proxy. The CLI itself ignores the config-file path docs (it knows the right location), so the bug only showed up in the curl-based recipe in operations/notes.md.

## Related

- Tracked as noetl/ai-meta#22.
- Follow-up to noetl/docs#170 (the original CLI docs refresh).
- Matching wiki fix: noetl-cli-wiki@e2f2681 (already pushed).

## Test plan

- [ ] yarn build (Docusaurus) — no broken links.
- [ ] Confirm `noetl context current` field names match the example layout against a live `~/.noetl/config.yaml`.
- [ ] Run the awk extractor in operations/notes.md against a real config and verify it returns the cached token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)