### PR TITLE
docs(operations): document batch.completed per-phase timing fields

### DIFF
--- a/docs/operations/batch-acceptance-async.md
+++ b/docs/operations/batch-acceptance-async.md
@@ -82,3 +82,73 @@ Exposed on `/metrics`:
 - `noetl_batch_queue_depth`
 - `noetl_batch_first_worker_claim_latency_seconds_sum`
 - `noetl_batch_first_worker_claim_latency_seconds_count`
+
+## Per-phase timings on `batch.completed`
+
+Every `batch.completed` event written to `noetl.event` carries a
+sub-phase timing breakdown in its `result.context` JSONB.  Operators
+can attribute tail latency to a specific code path (state load,
+`save_state` UPDATE, event-log INSERT, command issuance, lock
+acquire, etc.) directly from SQL.
+
+### Fields
+
+| field | meaning |
+|---|---|
+| `processing_ms` | end-to-end wall-clock for the batch job |
+| `pool_checkout_ms` | wall-clock to acquire the DB connection from the pool |
+| `lock_acquire_ms` | wall-clock to acquire `pg_advisory_xact_lock` for this `execution_id` |
+| `state_load_ms` | wall-clock for the initial state read |
+| `engine_total_ms` | wall-clock for the entire `handle_event` invocation |
+| `save_state_ms` (+ `_calls`) | total time across all `save_state` calls within one `handle_event` |
+| `save_state_terminal_lightweight_ms` (+ `_calls`) | time in the terminal-event fast-path UPDATE |
+| `persist_event_compat_ms` (+ `_calls`) | time across single-event + batched event-log INSERTs |
+| `save_state_coalesced_count` | number of intermediate `save_state` writes elided per `handle_event` |
+| `commit_ms` | wall-clock for the final `conn.commit()` |
+| `transaction_ms` | engine + commit block wall-clock |
+| `issue_commands_ms` | wall-clock for `_issue_commands_for_batch` after the engine returns |
+| `actionable_event` | `true` when the event reached `handle_event`; `false` for noop dispatches |
+| `commands_generated` | number of `noetl.command` rows emitted |
+
+### Picking a mitigation from data
+
+After a deploy or workload change, the dominant `*_ms` column over
+the first ~100 batches tells you which sub-phase is the new
+headline cost.
+
+```sql
+SELECT (result->'context'->>'commands_generated')::int AS cg,
+       COUNT(*) AS n,
+       ROUND((PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY
+         (result->'context'->>'engine_total_ms')::double precision))::numeric, 2) AS et_p90,
+       ROUND((PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY
+         (result->'context'->>'save_state_ms')::double precision))::numeric, 2) AS ss_p90,
+       ROUND((PERCENTILE_CONT(0.9) WITHIN GROUP (ORDER BY
+         (result->'context'->>'persist_event_compat_ms')::double precision))::numeric, 2) AS pec_p90
+FROM noetl.event
+WHERE event_type = 'batch.completed'
+  AND created_at > NOW() - INTERVAL '30 minutes'
+  AND (result->'context'->>'save_state_ms') IS NOT NULL
+GROUP BY 1 ORDER BY 1;
+```
+
+Three write-elision optimisations ship in the engine to keep these
+columns bounded:
+
+- **Terminal-event fast path** — late-arriving events against an
+  already-completed execution skip the heavy state JSONB rewrite
+  and only advance `last_event_id`.
+- **Cascade event-log batching** — `workflow.completed` →
+  `playbook.completed` (and the failure equivalent) are persisted
+  with one `executemany INSERT`, sharing a single snowflake-ID
+  allocation and a single duration lookup.
+- **save_state coalescing** — intermediate state writes inside one
+  `handle_event` are stashed in a contextvar buffer and flushed
+  ONCE at handle_event exit, after all events have been persisted
+  (textbook event-sourcing order — append to log first, project
+  afterwards).
+
+See the noetl/noetl wiki page
+[handle_event timing](https://github.com/noetl/noetl/wiki/handle_event_timing)
+for the full architectural breakdown, contextvar plumbing details,
+and operator query recipes.


### PR DESCRIPTION
## Summary

Documents the per-phase timing fields that now land in every \`batch.completed\` event's \`result.context\` JSONB.  Operators can attribute tail latency to a specific code path (state load, save_state UPDATE, event-log INSERT, command issuance, lock acquire, etc.) directly from SQL — no extra metrics exporter needed.

## Background

[noetl/ai-meta#29](https://github.com/noetl/ai-meta/issues/29) tracked a 5-round investigation of per-execution \`batch.completed\` tail latency.  The five PRs that shipped:

| Round | PR | What it added |
|---|---|---|
| 1 | [noetl/noetl#629](https://github.com/noetl/noetl/pull/629) | Per-batch timing instrumentation (8 fields) |
| 2 | [noetl/noetl#630](https://github.com/noetl/noetl/pull/630) | Terminal-event fast path |
| 3 | [noetl/noetl#633](https://github.com/noetl/noetl/pull/633) | Sub-phase instrumentation (engine_total_ms breakdown) |
| 4 | [noetl/noetl#635](https://github.com/noetl/noetl/pull/635) | Cascade event-log batching |
| 5 | [noetl/noetl#637](https://github.com/noetl/noetl/pull/637) | save_state coalescing |

Cumulative result: cg=0 \`processing_ms\` max dropped 1262ms → 264ms (−79%).

## What's added to the docs page

Section: **Per-phase timings on \`batch.completed\`** in \`operations/batch-acceptance-async.md\`.

- Full field catalogue (14 fields).
- SQL recipe for picking the next mitigation target by dominant \`*_ms\` column.
- Summary of the three write-elision optimisations.
- Link to the noetl/noetl wiki page [\`handle_event timing\`](https://github.com/noetl/noetl/wiki/handle_event_timing) for the architectural deep-dive.

## Companion changes

The noetl/noetl wiki page is already merged: [handle_event timing](https://github.com/noetl/noetl/wiki/handle_event_timing) (commit \`20c4e26\`).  This PR cross-links from the user-facing docs site.

## Test plan

- [ ] Docusaurus build succeeds.
- [ ] Field table renders correctly in the rendered page.
- [ ] Wiki link resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)