### PR TITLE
docs(architecture): revise Appendix H (§ H.10 tree-walker finding + § H.11 local Feather buffer + § H.12 dynamic playbooks) + MinIO exclusion

### DIFF
--- a/docs/architecture/noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint.md
+++ b/docs/architecture/noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint.md
@@ -1358,38 +1358,71 @@ The runtime should move toward Rust where Rust earns its keep and stay Python wh
 
 The blueprint does not endorse a full Python-to-Rust rewrite of the production platform. A rewrite restarts the regression-cost clock for code that already absorbed the v2-spec phases and the post-spec performance work.
 
-## **H.3 The architectural hinge: unified CLI + worker executor**
+## **H.3 The architectural hinge: shared utilities, distinct control loops**
 
-`repos/cli/src/playbook_runner.rs` already executes playbooks locally by invoking the `noetl-tools` crate inline. `repos/worker` executes the same `noetl-tools` calls but pulls commands from a NATS durable consumer. The two paths are roughly 95% identical execution logic and 5% command-source plumbing. Unifying them around a shared executor crate is the highest-leverage early step.
+> **Note (2026-05-30):** the original wording of this section claimed CLI and worker were "95% identical execution logic" unified behind one `CommandSource` trait.  After R-1.1 PR-1 + PR-2a landed and the post-extraction `playbook_runner.rs` was surveyed in depth, that claim was found wrong in one important way: the CLI is a **tree walker** and the worker is a **pull-model consumer**.  These control loops are fundamentally different shapes; only the utilities under them are shared.  § H.10 documents the finding and the resulting plan revision in full; the rest of this section has been rewritten to match.
 
-Target layout:
+`repos/cli/src/playbook_runner.rs` executes playbooks locally as a recursive tree walker — it loads the YAML, walks the workflow, evaluates `next` arcs / `case` conditions / `then` blocks in place, and dispatches each step to a tool implementation inline.  `repos/worker` executes one command at a time pulled from a NATS durable consumer, with no tree to walk and no recursive routing decisions — the engine on the server side made those already.
+
+These are **fundamentally different control loops**.  An attempt to flatten the CLI's tree walker into a pull-model iterator loses local-debug clarity (the tree shape is gone) and produces awkward state management around `case` / `then` recursion.  The unified-executor abstraction in the original Appendix H draft is the wrong abstraction for the CLI.
+
+What CLI and worker actually share — and what `noetl-executor` should host — are **utilities and types**, not the control loop:
+
+Revised target layout:
 
 ```
-repos/executor/   <-- new crate noetl-executor
+repos/cli/executor/    (noetl-executor workspace crate)
   Cargo.toml
   src/
     lib.rs
-    runtime.rs            // ExecutionContext, EventEmitter, CredentialResolver
-    source.rs             // trait CommandSource { async fn next() -> Option<Command>; }
-    sources/
-      local_playbook.rs   // parses YAML, generates commands inline (CLI run mode)
-      nats.rs             // subscribes to NATS durable consumer (worker mode)
-    dispatch.rs           // routes Command -> tool kind -> noetl-tools registry
-    events.rs             // emits noetl events; pluggable EventSink trait
-    state.rs              // in-memory ExecutionState mirror with replay-friendly shape
+    playbook.rs                       // YAML types (R-1.1 PR-2a, MERGED)
+    template.rs                       // Jinja2 + Rhai rendering (R-1.1 PR-2b)
+    condition.rs                      // when / case condition evaluation (R-1.1 PR-2b)
+    credentials.rs                    // $noetl_ref resolution + redaction (R-1.1 PR-2b)
+    runtime.rs                        // ExecutionContext, EventEmitter,
+                                      // CredentialResolver (R-1.1 PR-1, MERGED)
+    events.rs                         // EventSink trait + ExecutorEvent shape
+                                      // (R-1.1 PR-1, MERGED)
+    worker/                           // worker-specific control loop pieces
+      source.rs                       // trait CommandSource — WORKER-ONLY
+                                      // abstraction; CLI does not use it
+      sources/
+        nats.rs                       // NATS pull consumer (R-1.3)
+      dispatch.rs                     // route Command -> tool kind via
+                                      // noetl-tools registry (R-1.3)
 
-repos/cli/        <-- depends on noetl-executor; uses LocalPlaybookSource
-repos/worker/     <-- depends on noetl-executor; uses NatsCommandSource + persistent EventSink
+repos/cli/        <-- depends on noetl-executor; uses utilities only;
+                      keeps its own tree walker in playbook_runner.rs
+repos/worker/     <-- depends on noetl-executor; uses utilities + CommandSource
+                      + NatsCommandSource impl
 ```
 
-Both `noetl run --runtime local <playbook.yaml>` and the worker daemon flow through the same execution core. The CLI gets full distributed-runtime semantics in local mode for free (event log, replay, credential resolution); the worker gets the CLI's ergonomic single-binary debug surface. Future tools added to `noetl-tools` are available to both paths from day one.
+Both binaries depend on `noetl-executor` for the same set of utilities (template rendering, condition evaluation, credential resolution, event emission shape, YAML types).  The CLI keeps its recursive tree walker (lines 213-770 of `playbook_runner.rs` — `run`, `execute_step`, `execute_next_steps`, `execute_router_arcs`, etc.) because that shape is the natural fit for local YAML execution.  The worker keeps its NATS pull loop because that shape is the natural fit for distributed-runtime semantics.
 
-Existing CLI features that move into the shared crate:
+What this gives up vs the original vision:
 
-* Tool dispatch and kind resolution from `playbook_runner.rs`.
-* Credential / keychain `$noetl_ref` resolution (currently CLI-side).
-* Template rendering against the merged step context.
-* Event-emission semantics matching the Python worker's `noetl.runtime.events.report_event`.
+- The CLI does NOT get distributed-runtime semantics in local mode for free.  Local mode stays the lightweight tree-walker shape.  If a CLI user wants distributed-runtime semantics, they invoke a remote server via the `noetl-sdk` (R-4 / § H.9).
+- The worker does NOT get the CLI's ergonomic single-binary debug surface.  The worker is a daemon by nature.
+
+What this still gains:
+
+- Type-safe parsed playbook shape (R-1.1 PR-2a, shipped).
+- Shared Jinja2 + Rhai template rendering (R-1.1 PR-2b).
+- Shared `$noetl_ref` credential resolution + response-boundary redaction (R-1.1 PR-2b).
+- Shared event-emission shape matching the Python `noetl.runtime.events.report_event` envelope (R-1.1 PR-1, shipped).
+- Shared Arrow-IPC codec + cache (R-2).
+- Shared tool registry via `noetl-tools` (R-3).
+
+Existing CLI features that move into `noetl-executor` (R-1.1 PR-2b's revised scope):
+
+* Template rendering against the merged step context (`render_template`, `render_template_with_result`, `get_json_path`, `json_to_rhai`, `rhai_to_json_string`).
+* Condition evaluation (`evaluate_condition`, `evaluate_rhai_condition`).
+* Capability validation (`validate_capabilities`).
+
+What does NOT move into `noetl-executor`:
+
+* The tree-walker control loop (`run`, `execute_step`, `execute_next_steps`, `execute_router_arcs`) — stays in `playbook_runner.rs`.
+* The inline tool execution logic (`execute_tool`, `execute_shell_command`, `execute_http_request`, `execute_duckdb_query`, etc.) — R-1.1 PR-2c replaces these with calls into the `noetl-tools` registry.
 
 ## **H.4 Apache Arrow-native data plane in Rust**
 
@@ -1419,13 +1452,15 @@ The plan is structured so each phase delivers measurable value and has a clear s
 
 ### **Phase R-1 — `noetl-executor` shared crate (~1–2 months)**
 
-* Extract local execution logic from `repos/cli/src/playbook_runner.rs` into a new `repos/executor/` crate.
-* Define the `CommandSource` trait with `LocalPlaybookSource` and `NatsCommandSource` implementations.
-* Both `repos/cli` (`noetl run --runtime local`) and `repos/worker` (NATS daemon) depend on `noetl-executor`.
-* `noetl-tools` stays the tool registry.
-* Existing CLI tests pass against the new core.
-* Ship criterion: ≥80% shared code path between the CLI local-mode and worker NATS-mode execution.
-* Stop criterion: if extraction creates more abstraction than it removes, keep the two paths separate and revisit unification after Arrow integration (R-2).
+* **REVISED 2026-05-30 — see § H.10 for the architectural finding that forced this revision.**
+* Bootstrap `noetl-executor` as a workspace crate under `repos/cli/` (R-1.1 PR-1 — **MERGED** as noetl/cli#20).
+* Extract the YAML playbook types from `playbook_runner.rs` into `noetl-executor::playbook` (R-1.1 PR-2a — **MERGED** as noetl/cli#21).
+* Extract template rendering + condition evaluation + capability validation + credential resolution helpers into `noetl-executor::{template, condition, credentials}` (R-1.1 PR-2b — revised scope, ~430 LoC).
+* Replace the CLI's inline tool execution (`execute_tool` and friends) with calls into the `noetl-tools` registry (R-1.1 PR-2c, ~870 LoC).
+* The CLI's tree walker (`run`, `execute_step`, `execute_next_steps`, `execute_router_arcs`) **stays in `playbook_runner.rs`**.  Closing R-1.1 (PR-2d): `noetl/cli#19` closes when the CLI's tree walker only contains control-flow logic and delegates every other concern to `noetl-executor` + `noetl-tools`.
+* The worker (R-1.3) depends on `noetl-executor` for utilities and for its own `CommandSource` / `NatsCommandSource` impls.  `CommandSource` is a worker-only abstraction; the CLI does not implement or consume it.
+* Ship criterion: the CLI's local-mode runner consumes the same `noetl-executor` utility surface that the worker does; the **two binaries share types, template rendering, condition evaluation, credential resolution, and tool dispatch via `noetl-tools`**, but each owns its own control loop.
+* Stop criterion: if utility extraction creates more abstraction than it removes (e.g. template rendering needs a per-binary ExecutionContext that's too divergent), keep that utility in `playbook_runner.rs` for now and revisit after R-2 lands.
 
 ### **Phase R-2 — Apache Arrow Rust integration (~1 month, parallel to R-1)**
 
@@ -1550,3 +1585,90 @@ Recommended package names at R-4 ship:
 * Crates.io publish flag flips from `publish = false` to `publish = true` per crate as its API stabilises.
 
 The user-visible Python import stays `import noetl as nt`.  Code that runs today against `noetl/noetl` v2.103.x runs unchanged against `pip install noetl` after R-4 lands.
+
+## **H.10 Architectural finding (2026-05-30): tree walker vs pull-model**
+
+This section records an architectural finding that surfaced after R-1.1 PR-1 (executor skeleton) and PR-2a (YAML types extraction) landed and the post-extraction `playbook_runner.rs` was surveyed in depth.  The finding revises § H.3 and § H.5 R-1.1; § H.4 (Arrow) and § H.9 (Polars endpoint) are unaffected.
+
+### **H.10.1 The finding**
+
+The original Appendix H plan assumed the CLI and worker shared roughly 95% of their execution logic and that a unified `CommandSource` trait — `LocalPlaybookSource` for the CLI, `NatsCommandSource` for the worker — would be the integration surface.  Reality is different:
+
+- **CLI** (`repos/cli/src/playbook_runner.rs`, ~2,277 LoC after PR-2a): the runner is a **recursive tree walker**.  It loads the YAML playbook, walks the workflow steps recursively, evaluates `next` arcs / `case` conditions / `then` blocks in place, and dispatches each step to a tool implementation inline.  Control flow is the call stack.
+- **Worker** (`repos/worker/`, ~1.9k LoC skeleton today): the runner is a **pull-model consumer**.  It subscribes to a NATS durable consumer, pulls one command at a time, executes it, emits events, and repeats.  No tree.  No recursion.  No routing decisions — the server's engine made those already and emitted typed commands.
+
+Flattening the CLI's tree walker into a pull-model iterator is doable in principle but has real costs:
+
+- Local-debug clarity drops.  A user running `noetl run --runtime local foo.yaml` benefits from the call stack mirroring the YAML structure.  A flattened iterator loses that mapping.
+- The implementation needs explicit state management for `case` / `then` recursion.  The recursive tree walker gets this for free from the language.
+- The integration tests written against the tree shape (assertions like "step A's next arc ran after step A's tool call returned") would need rewriting.
+
+The cost-benefit doesn't justify the change.
+
+### **H.10.2 Revised target shape**
+
+`noetl-executor` becomes a **utilities-and-types crate**, not a **control-loop crate**.  Both CLI and worker depend on it for:
+
+- YAML types (`playbook::*`) — shipped in PR-2a.
+- Template rendering (Jinja2 + Rhai) — moves in PR-2b.
+- Condition evaluation (`when`, `case`) — moves in PR-2b.
+- Capability validation — moves in PR-2b.
+- Credential resolution (`$noetl_ref`) + response-boundary redaction — moves in PR-2b.
+- Event-emission shape (`ExecutorEvent`, `EventSink` trait) — shipped in PR-1.
+- Arrow-IPC codec helpers — shipped in R-2.1 PR.
+- Tool dispatch via `noetl-tools` registry — wired in PR-2c.
+
+Each binary owns its control loop:
+
+- The CLI owns its recursive tree walker (`run`, `execute_step`, `execute_next_steps`, `execute_router_arcs`).  It stays in `playbook_runner.rs`.
+- The worker owns its NATS pull loop.  `CommandSource` and `NatsCommandSource` live under `noetl-executor::worker::*` and are worker-only.
+
+### **H.10.3 What R-1.1 PR-2b looks like under the revised plan**
+
+R-1.1 PR-2b shifts from "lift the parser + command-generation logic (~1,200 LoC) into `LocalPlaybookSource`" to:
+
+- Extract shared utility methods from `playbook_runner.rs` impl into new `noetl-executor` modules:
+  - `noetl-executor::template` — `render_template`, `render_template_with_result`, `get_json_path`, `json_to_rhai`, `rhai_to_json_string`.
+  - `noetl-executor::condition` — `evaluate_condition`, `evaluate_rhai_condition`.
+  - `noetl-executor::capabilities` — `validate_capabilities` and the `RuntimeCapabilities` factory methods.
+- Replace the inline method definitions in `playbook_runner.rs` with calls into the new modules.
+- ~430 LoC of utility extraction; control loop untouched.
+
+The placeholder `LocalPlaybookSource` introduced in PR-1 (queue-backed source for testing the trait machinery) is **removed** as part of PR-2b since the abstraction it sketched is not how the CLI works.  The `CommandSource` trait moves under `noetl-executor::worker::source` to make its scope explicit.
+
+### **H.10.4 What R-1.1 PR-2c and PR-2d look like under the revised plan**
+
+- **PR-2c** (~870 LoC): replace the CLI's inline tool execution (`execute_tool`, `execute_shell_command`, `execute_rhai_script`, `execute_http_request`, `execute_duckdb_query`, etc.) with calls into the `noetl-tools` registry.  The CLI adds `noetl-tools` as a regular dependency.  After this lands, the CLI and worker run the same tool implementations.
+- **PR-2d** (small): close `noetl/cli#19` with a final pass that documents the new shape in the CLI README + wiki, and confirms via integration tests that the CLI's tree walker only contains control-flow logic.
+
+### **H.10.5 What R-1.2 and R-1.3 look like under the revised plan**
+
+- **R-1.2** is folded into PR-2b/2c — there is no separate "CLI depends on noetl-executor" PR; the CLI gains the dependency in PR-2b and uses more of the executor surface in PR-2c.
+- **R-1.3** (worker depends on noetl-executor) becomes the moment the worker grows beyond skeleton size.  It depends on `noetl-executor::{playbook, template, condition, credentials, events}` AND `noetl-executor::worker::{source, sources::nats}`.  The CLI continues to depend on the utility modules only.
+
+### **H.10.6 Why this is the right call**
+
+The original Appendix H draft was written before R-1.1 PR-1 / PR-2a landed and before the post-PR-2a state was surveyed in depth.  Three rounds of code-level inspection (the PR-1 skeleton design, the PR-2a types extraction, and the post-PR-2a survey that produced this finding) revealed that the "95% identical execution logic" framing was wrong.  The honest answer is closer to "60% identical *utility* logic, 0% identical *control loop* logic."
+
+Recording this in writing — instead of quietly proceeding with the wrong abstraction — protects future sessions from re-running the same investigation and protects R-1.3 (worker) from inheriting a shape it doesn't want.
+
+### **H.10.7 What does not change**
+
+- The Polars-pattern endpoint (§ H.9) is unchanged.  Whether `pip install noetl` ships a Rust runtime + PyO3 wrapper is independent of whether that runtime's local mode uses a tree walker or a pull loop.
+- The phased R-1 / R-2 / R-3 / R-4 cadence is unchanged.  Phases ship in the same order; only R-1's internal scope was wrong.
+- The Apache Arrow data plane (§ H.4) is unchanged.  Arrow is a payload format; it doesn't care which control loop produces or consumes the IPC bytes.
+- The compatibility contracts (Python `noetl.runtime.events.report_event` envelope shape, `noetl.command` row shape, `IpcHint` envelope) are unchanged.
+
+### **H.10.8 PRs affected**
+
+- R-1.1 PR-1 (#20, merged) — unchanged in retrospect; the `runtime`/`events`/`source`/`dispatch` modules it shipped are still the right scaffolding.  The `LocalPlaybookSource` placeholder in `sources/local_playbook.rs` gets removed in PR-2b.
+- R-1.1 PR-2a (#21, merged) — unchanged; the YAML types extraction is correct under both the old and new plan.
+- R-1.1 PR-2b (next) — rescoped per § H.10.3.  ~430 LoC of utility extraction instead of ~1,200 LoC of parser/command-generation logic.
+- R-1.1 PR-2c (after 2b) — rescoped per § H.10.4.  Replaces inline tool execution with `noetl-tools` calls.
+- R-1.1 PR-2d (after 2c) — rescoped per § H.10.4.  Documentation + integration-test pass; closes `noetl/cli#19`.
+
+### **H.10.9 Process note**
+
+Architectural findings that surface mid-implementation are normal.  The recovery path is the one this section demonstrates: stop coding, write the finding into the binding plan (this doc), and re-enter implementation with the revised scope.  Coding through an architectural mismatch is how plans become wrong on paper while the code drifts in the right direction silently — leaving future readers of the plan confused about what was decided and why.
+
+A similar process note in the noetl/ai-meta memory bank ([`2026-05-22 v2-spec Phase 3 audit refreshed`](https://github.com/noetl/ai-meta/blob/main/memory/archive/2026/05/20260522-212900-v2-spec-phase3-audit-refresh-and-observability-landed.md)) demonstrates the same recovery for the v2-spec Phase 3 audit-table drift.  Both follow the same pattern: write down the finding, revise the source of truth, then continue.

--- a/docs/architecture/noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint.md
+++ b/docs/architecture/noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint.md
@@ -78,7 +78,7 @@ A cross-region NoETL business operating system should not require one database t
 | :---- | :---- | :---- |
 | Postgres / Citus / Aurora PostgreSQL / Cloud SQL / AlloyDB / Azure Database for PostgreSQL | Authoritative catalog, active projections, control-plane metadata, tenant grants, replay indexes. | Default relational control store and shard-local projection store. |
 | ClickHouse | High-volume analytical projections, telemetry, runtime observability, cost/accounting facts, event analytics. | Global analytics plane for execution metrics, shard health, tenant cost, frame throughput, and large result summaries. |
-| Object storage: S3 / GCS / Azure Blob / MinIO / Ceph / SeaweedFS | PayloadStore and cold archive for completed executions, Arrow/Parquet/Iceberg data files, validation bundles. | Primary cross-region data substrate with sharded bucket naming and immutable manifests. |
+| Object storage: S3 / GCS / Azure Blob / Ceph / SeaweedFS (NOT MinIO — see § 7 policy) | PayloadStore and cold archive for completed executions, Arrow/Parquet/Iceberg data files, validation bundles. | Primary cross-region data substrate with sharded bucket naming and immutable manifests. |
 | Apache Iceberg \+ Polaris / Gravitino | Open table format and catalog layer for tabular scientific and enterprise datasets. | Allows NoETL-generated datasets to be consumed by warehouses, Spark, Trino, Flink, Databricks, and notebooks. |
 | BigQuery / Redshift / Synapse / Microsoft Fabric / Snowflake / Databricks SQL | Customer-native warehouse projections and managed analytics backends. | Use as optional projection targets, not as the only runtime catalog. |
 | DuckDB | Local/vectorized post-processing, test fixtures, small/medium result packaging, notebook workflows. | Useful inside workers and archive validators; not a global coordination store. |
@@ -363,7 +363,13 @@ create table resource\_index (
 
 # **7\. Object Store Archive and Result Bundles**
 
-Object storage is the durable, cost-efficient place for historical execution data and large computational outputs. The object store layer must be pluggable: S3, GCS, Azure Blob Storage, NATS Object Store for small/simple deployments, MinIO, Ceph, or another S3-compatible in-house store.
+Object storage is the durable, cost-efficient place for historical execution data and large computational outputs. The object store layer must be pluggable: S3, GCS, Azure Blob Storage, NATS Object Store for small/simple deployments, Ceph RGW, SeaweedFS, or another S3-compatible in-house store.
+
+### **Object store policy: MinIO excluded from the recommended adapter list**
+
+MinIO is **not** part of the recommended S3-compatible adapter list for NoETL deployments. In-house S3-compatible storage SHOULD use Ceph RGW or SeaweedFS instead. The PayloadStore adapter for S3-compatible stores remains available — operators who must run MinIO can still point an `s3://` adapter at a MinIO endpoint — but MinIO is not in the supported, validated, or recommended set.
+
+MinIO retains a role only in the compliance-fixture suite (§ C.2, Appendix F.3) for parametrized adapter testing alongside Azurite, fake-gcs-server, and LocalStack / moto. Production and supported-deployment paths use Ceph RGW, SeaweedFS, S3, GCS, or Azure Blob.
 
 ## **Execution archive bundle**
 
@@ -511,7 +517,7 @@ noetl://default/demo/executions/archive/exec\_01HYABC@completed
 
 | Resource type | Description | Example physical storage |
 | :---- | :---- | :---- |
-| execution\_archive | Archived event log, manifests, checksums, and lineage for a completed execution | s3://, gs://, az://, minio://, ceph:// |
+| execution\_archive | Archived event log, manifests, checksums, and lineage for a completed execution | s3://, gs://, az://, ceph://, seaweed:// (see § 7 policy: MinIO is not in the recommended adapter list) |
 | result | Task or workflow output, usually referenced by manifest rather than embedded in events | Object store object, database rowset, Iceberg table snapshot |
 | dataset | Reusable structured or semi-structured data asset | Iceberg table, Parquet folder, Delta-like layout, database table |
 | model | ML/AI model artifact, checkpoint, adapter, embedding model, or prompt pack | Object store bundle, model registry pointer |
@@ -883,13 +889,13 @@ Remaining future work for true cross-language zero-copy (still tracked):
 
 ## **Cloud-native and hybrid adapter model**
 
-NoETL should keep the control-plane contracts portable and implement cloud-specific or datacenter-specific behavior behind ports/adapters. This allows a university lab to run a private MinIO/Ceph/NATS/Postgres cell while another tenant runs on S3/GCS/Azure Blob, Pub/Sub/Event Hubs/SQS, and managed Postgres-compatible databases.
+NoETL should keep the control-plane contracts portable and implement cloud-specific or datacenter-specific behavior behind ports/adapters. This allows a university lab to run a private Ceph/SeaweedFS/NATS/Postgres cell while another tenant runs on S3/GCS/Azure Blob, Pub/Sub/Event Hubs/SQS, and managed Postgres-compatible databases.  See § 7 for the object-store recommendation policy that excludes MinIO from the supported in-house adapter list.
 
 | Port | Cloud-native adapters | Hybrid / datacenter adapters |
 | :---- | :---- | :---- |
 | EventStore | NATS JetStream, Kafka-compatible services, cloud stream services where appropriate | NATS JetStream, Kafka/Redpanda, Postgres append log |
 | CommandQueue | NATS JetStream, Pub/Sub, SQS, Event Hubs, Service Bus | NATS JetStream, RabbitMQ, Kafka/Redpanda, Postgres queue |
-| PayloadStore | S3, GCS, Azure Blob, cloud HDFS-compatible stores | MinIO, Ceph RGW, on-prem S3-compatible store, NFS-backed object gateway |
+| PayloadStore | S3, GCS, Azure Blob, cloud HDFS-compatible stores | Ceph RGW, SeaweedFS, on-prem S3-compatible store, NFS-backed object gateway (see § 7 — MinIO excluded from recommended set) |
 | ProjectionStore | Cloud Postgres, AlloyDB, Cloud SQL, Aurora/RDS, BigQuery/ClickHouse for analytical views | Postgres, Citus, Timescale, ClickHouse, DuckDB for local/materialized views |
 | CatalogStore | Managed Postgres-compatible shards plus object manifest archive | Self-managed Postgres shards plus object manifest archive |
 
@@ -997,7 +1003,7 @@ The first implementation should be intentionally small but should use the same a
 local/kind or single cloud region:  
   \- one NATS JetStream cluster  
   \- one Postgres instance  
-  \- one object-store bucket or MinIO bucket  
+  \- one object-store bucket (cloud) or Ceph RGW / SeaweedFS bucket (in-house — see § 7)  
   \- one control-plane API  
   \- one worker pool  
   \- one archive service  
@@ -1141,7 +1147,7 @@ The following checklist is required for the blueprint to be complete enough for 
 | Cluster-aware NATS client routing | NATSCommandPublisher must pick the NATS endpoint from URN locality and catalog metadata, not static config alone. | Implement NatsEndpointResolver using tenant/org/region/zone/cluster. Emit command.route.selected and command.route.failed events for replay and audit. |
 | Per-tenant NATS accounts | The NATS supercluster generator must create account-level isolation for tenants and optionally projects/labs. | Generate NOETL platform account plus TENANT\_\* accounts, subject exports/imports, quotas, JWT/operator config, and tenant-scoped JetStream limits. |
 | Cross-cluster stream mirror/source | Use JetStream mirror/source for regional replica and aggregation patterns. Commands should remain owner-routed; events and projection notifications may mirror/source across cells. | Generate mirror/source manifests for NOETL\_EVENTS, NOETL\_PROJECTIONS, catalog-change streams, and archive notification streams. Validate failover and replay semantics. |
-| Registered PayloadStore spill path | Every storage-tier spill goes through PayloadStoreRegistry and returns a typed PayloadReference. Workers must not write raw provider URIs without registration. | Add spill policy to TempStore/Arrow cache/outbox path. Validate filesystem, S3, GCS, Azure Blob, SeaweedFS/MinIO S3-compatible stores. |
+| Registered PayloadStore spill path | Every storage-tier spill goes through PayloadStoreRegistry and returns a typed PayloadReference. Workers must not write raw provider URIs without registration. | Add spill policy to TempStore/Arrow cache/outbox path. Validate filesystem, S3, GCS, Azure Blob, SeaweedFS, Ceph RGW (S3-compatible) stores. |
 | Replay URI adapter resolution | ReplayPayloadResolver must resolve s3://, gs://, azure://, abfs://, file://, and noetl:// references through the correct adapter and return bounded checksum/shape summaries. | Add adapter registry tests for all supported schemes. Replay must fail closed if a payload reference is unresolved unless an explicit degraded replay mode is requested. |
 | Process-emulator compliance fixture | Cloud adapters must join the same parametrized compliance suite using local emulators where possible. | Add CI fixture using Azurite for Azure Blob, fake-gcs-server for GCS, moto or LocalStack for S3, and SeaweedFS/MinIO for S3-compatible object stores. |
 
@@ -1267,7 +1273,7 @@ azure://     AzureBlobPayloadStore
 abfs://      Azure Data Lake / Blob adapter  
 file://      FilesystemPayloadStore  
 seaweed://   SeaweedFS adapter or S3-compatible adapter  
-minio://     S3-compatible adapter  
+minio://     S3-compatible adapter (test/compliance-fixture only — see § 7 policy)  
 ReplayPayloadResolver should return deterministic summaries by default: checksum, row count, Arrow schema fingerprint, JSON shape summary, byte size, and resolution status. Full payload bodies should be opt-in and bounded by policy.
 
 ## **F.3 Process-emulator compliance fixture**
@@ -1277,7 +1283,7 @@ Cloud payload adapters need a process-emulator compliance fixture so they can jo
 * Azurite for Azure Blob and ADLS-compatible test paths.  
 * fake-gcs-server for GCS object-store behavior.  
 * moto or LocalStack for S3 behavior and AWS SDK compatibility.  
-* SeaweedFS or MinIO for S3-compatible in-house object storage.  
+* SeaweedFS (recommended) or MinIO (test/compliance only — see § 7) for S3-compatible in-house object storage.  
 * A single pytest parametrized compliance suite for put/get/head/delete/list, metadata sidecars, checksum validation, atomic write expectations, region/locality metadata, replay resolution, and failure injection.  
 * CI profiles: fast unit mocks, process-emulator integration tests, and optional live-cloud certification tests guarded by credentials and cost controls.
 
@@ -1298,7 +1304,7 @@ Cloudflare global entrypoints
        \- Kubernetes \+ KEDA for durable workers/projectors/cache/GPU/TPU/QPU/datacenter  
        \- AWS ECS/Fargate/Lambda containers, Azure Container Apps, GCP Cloud Run Jobs  
   \-\> Payload and Data Plane  
-       \- S3 / GCS / Azure Blob / MinIO / SeaweedFS / Ceph  
+       \- S3 / GCS / Azure Blob / Ceph RGW / SeaweedFS (MinIO excluded — see § 7)  
        \- Postgres / AlloyDB / Cloud SQL / Aurora / Azure PostgreSQL  
        \- ClickHouse / BigQuery / Redshift / Synapse-Fabric / Snowflake / Databricks / DuckDB  
        \- Qdrant / OpenSearch / vector and search adapters  
@@ -1672,3 +1678,192 @@ Recording this in writing — instead of quietly proceeding with the wrong abstr
 Architectural findings that surface mid-implementation are normal.  The recovery path is the one this section demonstrates: stop coding, write the finding into the binding plan (this doc), and re-enter implementation with the revised scope.  Coding through an architectural mismatch is how plans become wrong on paper while the code drifts in the right direction silently — leaving future readers of the plan confused about what was decided and why.
 
 A similar process note in the noetl/ai-meta memory bank ([`2026-05-22 v2-spec Phase 3 audit refreshed`](https://github.com/noetl/ai-meta/blob/main/memory/archive/2026/05/20260522-212900-v2-spec-phase3-audit-refresh-and-observability-landed.md)) demonstrates the same recovery for the v2-spec Phase 3 audit-table drift.  Both follow the same pattern: write down the finding, revise the source of truth, then continue.
+
+## **H.11 Local-mode Arrow Feather batch buffering for events + commands**
+
+### **H.11.1 The optimization**
+
+When a NoETL playbook runs in **local mode** (the CLI's recursive tree walker, not the worker's NATS pull loop), every event and command the runner emits today goes through one of two paths:
+
+- **Connected mode**: HTTP POSTs to a remote `noetl/server` (one round-trip per event).
+- **Disconnected mode**: written to a local SQLite/JSON event log under `~/.noetl/`.
+
+Both shapes are wasteful for the common case where the user runs `noetl run --runtime local foo.yaml` against a fast local-disk environment.  The connected mode burns network round-trips on events that will all land in the same execution archive anyway; the disconnected mode burns disk syscalls and gives up the columnar shape that the rest of the pipeline expects.
+
+The optimization: **buffer the entire event + command stream of one local execution as in-memory Arrow `RecordBatch` values, dump them to a single Feather V2 file on local disk during the run, and push the full batch to the remote event log atomically at execution exit**.  When the local execution completes successfully, the runner uploads the Feather file as one `batch.completed` envelope.  When it fails, the runner uploads what was buffered up to the failure point, then the failure-recovery event.
+
+### **H.11.2 Why Arrow Feather**
+
+The Rust `arrow-rs` crate family (already added to `noetl-tools` in R-2.1) ships:
+
+- `arrow::array::RecordBatch` — typed columnar batch with schema.
+- `arrow-ipc::writer::FileWriter` — Feather V2 / IPC file format writer.
+- `arrow-ipc::reader::FileReader` — random-access reader for replay and partial restore.
+
+This makes the local buffer:
+
+- **Compact** — Feather V2 dictionary-encoded columns are 5-10× smaller than the equivalent JSON event log on disk.
+- **Replay-friendly** — the same `IpcHint` envelope the worker uses to consume Python-produced Arrow segments (§ H.4) works for replay of a local-mode execution against a remote server.
+- **Crash-safe** — Feather V2 files are append-only with chunk-boundary footers; an interrupted local run keeps the events up to the last footer.
+
+### **H.11.3 Shape**
+
+Per-execution layout under `~/.noetl/local/<execution_id>/`:
+
+```
+~/.noetl/local/<execution_id>/
+  events.feather              // append-only Arrow RecordBatch chunks
+  commands.feather             // append-only Arrow RecordBatch chunks
+  metadata.json                // execution_id, started_at, playbook_path, status
+  payloads/                    // out-of-line large payloads (>4 MiB threshold)
+    <event_id>.arrow           // referenced from events.feather via PayloadReference
+```
+
+Schema for `events.feather`:
+
+| column | type | source field |
+|---|---|---|
+| `event_id` | Int64 | snowflake id allocated locally |
+| `execution_id` | Int64 | parent execution |
+| `event_type` | Utf8 | `batch.accepted`, `step.exit`, `call.done`, etc. |
+| `step` | Utf8 | step name |
+| `status` | Utf8 | `COMPLETED`, `FAILED`, `RUNNING` |
+| `created_at` | Timestamp(us, UTC) | wall-clock |
+| `context` | Binary (JSONB) | the event's context map serialized as JSON bytes |
+| `result` | Binary (JSONB) | the event's result envelope serialized as JSON bytes |
+| `meta` | Binary (JSONB) | meta map |
+| `parent_event_id` | Int64 (nullable) | parent event id |
+| `payload_ref` | Utf8 (nullable) | `local://payloads/<event_id>.arrow` when large payload exists |
+
+The `commands.feather` schema mirrors the Python-side `noetl.command` row shape from § 13's Command envelope.
+
+### **H.11.4 Flush policy**
+
+Three triggers for flushing the in-memory `RecordBatch` builder to disk:
+
+1. **Buffer-size threshold** (default 4 MiB): flush a batch and start a new one. Keeps each Feather chunk small enough to memory-map cleanly.
+2. **Execution exit** (success or failure): flush remaining buffer, write the metadata.json's `status` field, and close the file.
+3. **Idle timeout** (default 30 s) — for long-running local executions, flush periodically so partial recovery has bounded loss.
+
+### **H.11.5 Push-to-server contract**
+
+At execution exit (success or failure), the CLI POSTs the Feather files as one batched event envelope:
+
+```
+POST /api/events/batch
+Content-Type: application/vnd.apache.arrow.file
+X-NoETL-Execution-Id: <execution_id>
+X-NoETL-Event-Count: <count>
+
+<Feather V2 file bytes>
+```
+
+The server (R-4 Rust runtime + PyO3 wrapper) reads the Feather file, decodes the `RecordBatch` chunks, and applies them to the event log atomically inside one transaction.  Existing `batch.accepted` / `batch.processing` / `batch.completed` semantics from § 13 still apply; the only difference is that one HTTP call delivers ~thousands of events instead of one.
+
+When the user runs `noetl run --runtime local --offline foo.yaml`, the push step is skipped and the Feather files stay under `~/.noetl/local/<execution_id>/` indefinitely.  A separate `noetl push <execution_id>` command flushes them later.
+
+### **H.11.6 What this gains**
+
+- **Network round-trips**: ~thousands per execution → 1 per execution for connected local mode.
+- **On-disk footprint**: 5-10× smaller than the current JSON event log.
+- **Replay parity**: the same Feather + `IpcHint` machinery the worker uses for shared-memory cache reads (§ H.4) consumes local Feather buffers.  No new replay format.
+- **Offline-first ergonomics**: `--offline` runs produce reviewable Feather files; users can audit a local run before pushing it.
+
+### **H.11.7 What changes in the migration plan**
+
+- **R-2.1 follow-up** (`noetl-arrow-cache` crate per § H.4): add a `noetl-local-buffer` module that wraps the same Feather IPC writer for local-mode use.  Same code paths as the shared-memory cache; different sink (file vs `tmpfs`).
+- **R-1.1 PR-2b (revised per § H.10)**: keep the CLI's recursive tree walker as the local-mode control loop.  The `EventSink` impl swaps from "POST to server" to "append to Feather buffer".  No change to the tree walker's call graph.
+- **R-3 (worker tool parity)**: the worker continues to emit events via NATS as today.  No worker-side change.
+
+### **H.11.8 Implementation deferred to**
+
+- A new `R-1.4` phase under § H.5 once R-1.1 PR-2b lands.  Concrete scope: ~300 LoC for the `LocalEventBuffer` writer + ~150 LoC for the `noetl push` CLI command + Feather-aware batch ingestion on the server side (Rust, R-4).  Until R-4 the server-side ingestion stays Python; the Python `batch.accepted` path gains a content-type sniff to decode Arrow file bytes when it sees `application/vnd.apache.arrow.file`.
+
+## **H.12 Dynamically-generated playbook execution units**
+
+### **H.12.1 The scenario**
+
+NoETL's [agent-orchestration architecture doc](https://noetl.dev/docs/ai-meta/agent-orchestration) establishes that agents are themselves playbooks, dispatched via `tool: kind: agent` with `framework: adk|langchain|custom`.  The natural extension is **dynamically-generated playbooks** — playbook execution units produced at runtime by an upstream agent (typically an LLM via the ADK / LangChain / MCP bridges) rather than read from a static YAML file in the catalog.
+
+Example: a user submits a high-level intent ("rebuild the climate-research dataset from the upstream feed and notify the lab").  An LLM-backed agent decomposes the intent into a sequence of `noetl-tools` calls (data fetch → transformation → notification), emits the result as a Playbook YAML structure, and hands that structure to the runtime for execution.  The generated playbook is not in the catalog; it exists only for this one execution.
+
+This shape is referenced in the [ai-meta overview doc](https://noetl.dev/docs/ai-meta/overview) as part of the "shell, catalog, scheduler, execution fabric" pattern that makes NoETL a distributed business operating system.
+
+### **H.12.2 What this means for the runtime**
+
+The runtime must accept playbook execution units from three sources:
+
+| Source | Today | Tomorrow (with H.12) |
+|---|---|---|
+| Static YAML in the catalog | ✓ | ✓ |
+| YAML file on disk (CLI local mode) | ✓ | ✓ |
+| **Playbook object built in-memory by an upstream agent** | ✗ | ✓ |
+
+The third path requires:
+
+1. A **typed builder API** for constructing a `Playbook` value programmatically.  The `noetl-executor::playbook` module (shipped in R-1.1 PR-2a) already has the types; what's missing is an ergonomic builder.
+2. **Identity for ephemeral playbooks** — the runtime needs to assign a stable `playbook_id` to a generated execution unit so its events, lineage, and replay records have a consistent reference.  The catalog records a `kind: ephemeral` row with the generating-agent's execution_id as `parent_execution_id` and the generated YAML serialised as the row's `definition` field.  The ephemeral row is deletable after archival; the events that reference it keep their `playbook_id` foreign key.
+3. **A trust boundary** — generated playbooks must be policy-checked the same way catalog playbooks are.  An LLM-generated playbook MUST NOT inherit the generating agent's credential scope without an explicit grant; the policy engine evaluates the generated playbook against the tenant's grant table the same way it evaluates a catalog playbook.
+4. **A persistence contract** — the generated YAML is stored alongside the execution archive (§ 7) so replay reproduces the exact playbook the agent generated.  No "the agent ran something we can't see" gaps.
+
+### **H.12.3 Shape under the Rust + Polars-wrapper endpoint (§ H.9)**
+
+After R-4 ships and `pip install noetl` exposes the runtime through a PyO3 wrapper, the generation surface becomes:
+
+```python
+import noetl as nt
+
+# An agent (LangChain, ADK, OpenAI Assistants, or a custom planner)
+# decomposes a user intent into a typed Playbook.
+playbook = nt.Playbook.builder()
+    .workload({"trip_id": trip_id, "user_uid": uid})
+    .step("fetch_calendar")
+        .tool(kind="agent", framework="noetl",
+              entrypoint="travel/playbooks/catalog/calendar/list")
+    .next("emit_widget")
+    .step("emit_widget")
+        .tool(kind="python", code="def main(events): ...")
+    .build()
+
+# Hand the generated playbook to the runtime.
+outcome = nt.run(playbook, parent_execution_id=agent_exec_id)
+```
+
+The generated `Playbook` is a typed Rust value that crosses the PyO3 boundary once.  The runtime treats it identically to a catalog-loaded playbook from that point forward.  Events, lineage, archive bundle, replay all behave the same.
+
+### **H.12.4 Shape under the Rust-only worker (R-3)**
+
+The worker doesn't generate playbooks itself — generation is an agent-side concern.  But the worker must accept dispatched commands whose `playbook_ref` points at an ephemeral catalog row instead of a versioned catalog row.  This is one new condition in the `LoadPlaybook` step of the worker's NATS pull loop:
+
+```rust
+// pseudocode
+match cmd.playbook_ref.kind() {
+    PlaybookKind::Catalog => catalog.load(cmd.playbook_ref.id, cmd.playbook_ref.version),
+    PlaybookKind::Ephemeral => ephemeral_store.load(cmd.playbook_ref.id),
+}
+```
+
+`ephemeral_store` reads the agent-generated playbook from the catalog's `kind: ephemeral` rows.  The rest of the worker's dispatch is unchanged.
+
+### **H.12.5 Trust + audit**
+
+Three guardrails for generated playbooks:
+
+1. **Grant inheritance is explicit**.  The agent's execution context defines a `delegable_credentials` set listing the credential aliases the agent is permitted to pass into a generated playbook.  Generated playbooks reference credentials by alias only; resolution happens at step time against the delegated set, not the agent's full credential scope.
+2. **Tool-kind allowlist**.  The agent declares which `tool.kind` values its generated playbooks are permitted to dispatch.  An agent allowed to read data (kinds `http`, `postgres`, `duckdb`) cannot generate a playbook that runs `shell` or `python` unless explicitly granted.
+3. **Persistence audit**.  Every generated playbook is persisted in the execution archive (§ 7) alongside the events it produced.  Replay reproduces the exact playbook the agent generated; auditors can answer "what code did this agent decide to run?" deterministically.
+
+### **H.12.6 What changes in the migration plan**
+
+- **Phase R-5 (new in this section)**: add ephemeral-playbook support to the Rust runtime after R-4 ships.  Concrete scope: typed `Playbook` builder API on `noetl-executor::playbook` (~200 LoC); ephemeral catalog row + persistence (~300 LoC; needs Python catalog change too); grant-inheritance enforcement in the policy engine (~150 LoC).
+- **No R-1 / R-2 / R-3 change required**.  The current YAML loading paths continue to work; the ephemeral path is additive.
+- **Open questions** added to § H.8:
+  - Should the ephemeral catalog row hold the YAML as text or as a typed Playbook serialization?  Trade-off: YAML round-trips through the parser (slow, but human-readable in audit); typed serialization is faster but binary.
+  - Should generated playbooks be cached for re-use if the agent re-generates the same shape?  Cache key would be a structural hash of the typed Playbook.  Initial answer: no — agents that need stable playbooks should write them to the catalog explicitly.
+  - How does an LLM-generated playbook satisfy the [Catalog-Driven MCP Architecture](https://noetl.dev/docs/architecture/mcp_catalog_architecture)?  The catalog's MCP-discovery surface assumes registered playbooks; ephemeral playbooks would need explicit opt-in flagging if discoverable, defaulting to private.
+
+### **H.12.7 Relationship to the ai-meta agent-orchestration doc**
+
+The ai-meta [agent-orchestration page](https://noetl.dev/docs/ai-meta/agent-orchestration) frames NoETL as the "distributed business operating system" for AI agents — catalog, scheduler, executor, observability.  Dynamically-generated playbooks are the natural endpoint of that framing: when an agent IS a playbook, an agent that *plans* is an agent that *generates more playbooks*.  Cataloging every generated playbook would explode the catalog; treating them as ephemeral execution units lets the agent compose freely while keeping the execution archive complete and auditable.
+
+The pattern aligns with the [ai-meta overview doc](https://noetl.dev/docs/ai-meta/overview)'s "shell + catalog + scheduler + execution fabric + event log + observability" composition.  Generation becomes part of the shell layer; execution lands on the existing fabric without runtime-level changes beyond § H.12.4.


### PR DESCRIPTION
## Summary

Four blueprint updates that landed on the same branch after PR-2a merged and the user surfaced architectural input:

1. **§ H.10 — Architectural finding (tree walker vs pull-model)**.  R-1.1 PR-2b rescope based on post-PR-2a code survey.  See \"The finding\" below.
2. **§ H.11 — Local-mode Arrow Feather batch buffering for events + commands**.  CLI local mode buffers to a Feather V2 file, pushes one batched envelope to the remote event log at execution exit.  ~thousands of round-trips → 1.
3. **§ H.12 — Dynamically-generated playbook execution units**.  Handles the AI-generation case where playbooks are produced at runtime by an upstream agent (ADK / LangChain / MCP bridges per the [ai-meta agent-orchestration doc](https://noetl.dev/docs/ai-meta/agent-orchestration)) instead of read from the catalog.
4. **Object-store policy** — MinIO excluded from the recommended adapter list.  Production / supported-deployment paths use Ceph RGW, SeaweedFS, S3, GCS, or Azure Blob.  MinIO retains a role only in the compliance-fixture suite.

## The finding (§ H.10)

While starting R-1.1 PR-2b, surveyed the post-PR-2a state of \`repos/cli/src/playbook_runner.rs\` in depth and found that the original Appendix H plan was based on a wrong assumption about CLI/worker code-share:

- **CLI** is a recursive tree walker (loads YAML, walks workflow, evaluates \`next\` arcs / \`case\` conditions / \`then\` blocks in place, dispatches inline).  Control flow is the call stack.
- **Worker** is a pull-model consumer (subscribes to NATS, pulls one command at a time, no tree, no recursion, no routing decisions).
- These control loops are **fundamentally different shapes**.

The original Appendix H draft claimed \"95% identical execution logic\" unified behind a shared \`CommandSource\` trait.  That framing was wrong.  Flattening the CLI's tree walker into a pull-model iterator would lose local-debug clarity, complicate \`case\` / \`then\` state management, and break the integration tests written against the tree shape.

## What changes in the doc

| Section | Change |
|---|---|
| § H.3 | Title now \"shared utilities, distinct control loops\"; revised target layout; date-stamped correction at the top of the section. |
| § H.5 R-1.1 | New sub-PR scopes for PR-2b / PR-2c / PR-2d. |
| **§ H.10 (new)** | Full finding, rescope, process note. |
| **§ H.11 (new)** | Local-mode Feather buffer.  Schema, flush policy, push contract, R-1.4 phase. |
| **§ H.12 (new)** | Dynamically-generated playbooks.  Builder API, ephemeral catalog row, trust boundary, R-5 phase. |
| § 5, 7, 8, 14, 18, C.2, F.2, F.3, G.1 | MinIO replaced with Ceph RGW / SeaweedFS in supported-deployment lists; § 7 gains an explicit \"Object store policy\" subsection. |
| § H.4 (Arrow), § H.6/H.7/H.8 (open questions), § H.9 (Polars endpoint) | **Unchanged** — they were correct under both the old and new plan. |

## What changes in code

Noted in the doc but not implemented yet.  After this PR merges:

- R-1.1 PR-2b shifts from ~1,200 LoC parser-extraction to ~430 LoC utility extraction.
- R-1.1 PR-2c stays as the tool-dispatch replacement via \`noetl-tools\` (~870 LoC).
- R-1.1 PR-2d stays as documentation + integration-test pass to close noetl/cli#19.
- R-1.4 (new) lands the local-mode Feather buffer.
- R-5 (new) lands ephemeral playbook support.

## Why land this before more code

The honest path: stop coding, write the finding into the binding plan, then re-enter implementation with the revised scope.  Coding through an architectural mismatch is how plans become wrong on paper while the code drifts in the right direction silently — leaving future readers confused.

A similar recovery is on record in the noetl/ai-meta memory bank for the v2-spec Phase 3 audit-table drift (the \"shared-memory cache remains future work\" line that contradicted the doc's own audit table).  Same pattern: write down the finding, revise source of truth, then continue.

## Test plan

- [ ] Docusaurus build succeeds against the revised + new sections.
- [ ] § H.10 / § H.11 / § H.12 appear under Appendix H in the rendered TOC.
- [ ] § H.3's correction note's anchor link to § H.10 resolves.
- [ ] § 7's new \"Object store policy\" callout renders correctly.

Tracks noetl/ai-meta#30
Refs noetl/cli#19
Refs noetl/cli#20 (merged) + noetl/cli#21 (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)