### PR TITLE
docs(adr): WASM plug-in compile target, capability boundary, Arrow data plane

### DIFF
--- a/docs/architecture/event_wal_and_derivable_storage.md
+++ b/docs/architecture/event_wal_and_derivable_storage.md
@@ -99,9 +99,23 @@ Three problems, one model.
   model the orchestrator reads). This already exists.
 - **Materialiser pool** drains the same log, and for over-budget results
   writes Arrow Feather to object store at the logical URI's resolved
-  cell/shard prefix. The shadow
-  materialiser consumer already exists; this extends it to write the
-  durable Feather tier.
+  cell/shard prefix. The shadow materialiser consumer already exists;
+  this extends it to write the durable Feather tier.
+
+Both drain pools — and every async system service this model adds — run
+on the **system worker pool as plug-in-ring playbooks**, not as bespoke
+Rust services, per the
+[System Worker Pool and WASM Plug-in Surface](./system_pool_and_wasm_plugins.md)
+ADR. `system/outbox_publisher` and `system/projector` already run this
+way; the materialiser is the same shape — a `system/` playbook that
+drains `noetl_events` and calls the server's internal API to write the
+Feather tier. The worker's **parallel publish stays in the compiled core**
+(it is part of the worker binary's emit path, fired per atomic cycle —
+no extensibility need, no per-invocation dispatch cost). The split is:
+thin compiled publish on the hot path, system-pool playbooks for the
+heavy async drain/materialise/project work. Playbooks that later need
+native speed compile to WASM and hot-reload via catalog version bump (the
+ADR's Phase 4) — the catalog is the managed, replaceable plug-in library.
 
 ## The load-bearing decision: where the durability barrier sits
 
@@ -265,8 +279,11 @@ by derivation.
    location from identity.
 2. **Local-first dual write** — the worker's local buffer is the fast
    path; the JetStream publish is the durability channel (extends the
-   2d-3 worker-publish direction).
-3. **Arrow Feather durable tier** under the materialiser, keyed by URN.
+   2d-3 worker-publish direction). Stays in the compiled core.
+3. **Arrow Feather durable tier** under the materialiser — a **plug-in-ring
+   `system/` playbook** on the system worker pool, optionally WASM-compiled
+   for native speed and hot-reloaded via catalog version bump (the
+   [system-pool ADR](./system_pool_and_wasm_plugins.md) Phase 4).
 
 ## How it folds into the open work
 

--- a/docs/architecture/event_wal_and_derivable_storage.md
+++ b/docs/architecture/event_wal_and_derivable_storage.md
@@ -10,7 +10,8 @@ sidebar_position: 9
 How NoETL makes the event and result path fast **and** crash-resilient
 at the same time: treat NATS JetStream as the write-ahead log, run
 local memory as a read cache ahead of the last durable offset, derive
-result locations from a naming convention instead of carrying
+result locations from a stable logical URI that resolves to a cell/shard
+location instead of carrying
 references, and let independent pools project the log and materialise
 results to an Arrow Feather tier in object store.
 
@@ -34,10 +35,11 @@ publish-ack is the durability boundary: the stream is the write-ahead
 log. Two independent consumer pools drain that log — a **projector**
 that rebuilds the read model (`projection_snapshot`) and a
 **materialiser** that writes over-budget result payloads as Arrow
-Feather files to object store. Result locations are **derived from a
-naming convention** (a URN computed from the execution identity), so
-state carries predicate fields and derivable coordinates, never a
-payload and never an opaque reference string. A crashed instance resumes
+Feather files to object store. Result locations are addressed by a
+**stable logical URI** (`noetl://<tenant>/<project>/results/...`) that
+resolves to a physical location through the cell / shard model, so state
+carries predicate fields and derivable coordinates, never a payload and
+never an opaque, placement-coupled reference. A crashed instance resumes
 from the last log offset its work was durably acked at and replays only
 the local-only tail.
 
@@ -81,7 +83,7 @@ Three problems, one model.
    orchestrator / worker    projector pool   materialiser pool
    read the fast path       → projection_     → Arrow Feather in
                               snapshot           object store, keyed
-                              (read model)       by derived URN
+                              (read model)       at logical-URI loc
 ```
 
 - **Local buffer = read cache.** It accelerates a process reading its
@@ -96,7 +98,8 @@ Three problems, one model.
 - **Projector pool** drains the log into `projection_snapshot` (the read
   model the orchestrator reads). This already exists.
 - **Materialiser pool** drains the same log, and for over-budget results
-  writes Arrow Feather to object store under the derived URN. The shadow
+  writes Arrow Feather to object store at the logical URI's resolved
+  cell/shard prefix. The shadow
   materialiser consumer already exists; this extends it to write the
   durable Feather tier.
 
@@ -122,40 +125,88 @@ the recorded result adopted. This is the same shape as the
 callback/hook rule — time in the external system is free; the worker
 slot is only held while a block actually runs.
 
-## Derivable URN grammar
+## Derivable addresses: the logical URI and topology resolution
 
-The location is a pure function of execution identity. It must encode
-everything that distinguishes one result from another, or fan-out and
-retries collide on the same key:
+NoETL runs as a super-cluster spanning cloud providers, regions, zones,
+hybrid datacenters, and Kubernetes clusters, so a result's **name must
+resolve to where its bytes live** — without hard-coding a mutable
+physical placement into the name. This reuses the platform's existing
+two-layer naming from the
+[Global Hybrid Supercluster Blueprint](./noetl_global_hybrid_cloud_grid_distributed_architecture_blueprint.md)
+(§4 Regional Cell and Shard Model, §7 Object Store Archive, §8 NoETL
+Resource Locator) rather than inventing a parallel scheme.
 
-```
-urn:noetl:result:<execution_id>:<step>:<frame_or_claim_index>:<attempt>
-```
-
-- `execution_id` and `step` are already in the event envelope.
-- `frame_or_claim_index` is **mandatory** for fan-out. Cursor mode
-  produces many results per step; without the index, row 0 and row 5
-  write the same object and corrupt each other.
-- `attempt` disambiguates retries when you want both kept; omit it (or
-  fix it at the latest) when you want retries to **overwrite**.
-
-The object-store key is a deterministic encoding of the URN, e.g.
+### Layer 1 — the logical URI (stable, location-independent)
 
 ```
-noetl/<execution_id>/<step>/<frame>/<attempt>.feather
+noetl://<tenant>/<project>/results/<execution_id>/<step>/<frame>/<attempt>@<version>
 ```
 
-What the convention buys:
+This is the established NoETL Resource Locator shape
+(`noetl://<tenant>/<project>/<kind>/<logical_path>@<version>`). It is
+what state carries and what dedup / replay key on, and it **never
+changes** when data is replicated, migrated, or fails over — that is the
+whole point of a *name* rather than a *locator*. Encoding
+provider/region/cluster literally into the name would couple identity to
+mutable placement and break failover; topology is **resolved from** the
+name, not baked **into** it.
 
-- **Idempotent overwrite.** A retry that fixes `attempt` rewrites the
-  same key — no orphaned objects, single atomic PUT, clean reads.
-- **Trivial garbage collection.** TTL or end-of-execution cleanup is a
-  prefix delete (`noetl/<execution_id>/`).
-- **Deterministic replay.** The projector and any consumer **compute**
-  the URN from the envelope; the event never carries it. State shrinks to
-  the coordinates already present plus the predicate block below.
-- **Prefix discovery.** "All results for execution X" is a prefix list,
-  not a reference set to thread through state.
+- `tenant` and `project` lead — the multitenancy + sharding dimensions
+  (the coordinates an earlier draft of this doc omitted).
+- `execution_id` and `step` are in the event envelope.
+- `frame` is **mandatory** for fan-out — cursor mode produces many
+  results per step; without it, row 0 and row 5 collide.
+- `attempt` / `@version` disambiguate retries: fix the version to
+  **overwrite** (idempotent), bump it to **keep every attempt**.
+
+### Layer 2 — topology resolution (derivable, then a small registry)
+
+The logical URI resolves to a physical location through the §4 shard
+model, not a per-result lookup:
+
+```
+shard_key = hash(tenant_id + project_id + execution_affinity) % shard_count
+          → region + cell + shard
+```
+
+which yields the §7 physical object prefix:
+
+```
+noetl/env=<env>/region=<region>/cell=<cell>/shard=<shard>/
+      tenant=<tenant>/project=<project>/date=<date>/
+      execution=<execution_id>/results/<step>/<frame>/<attempt>.feather
+```
+
+A consumer that knows `(tenant, project, execution_id)` therefore
+**derives** the home region / cell / shard and the prefix with zero
+central lookup — the "find without passing references" property, made
+topology-aware. The only thing that needs a registry is the small,
+slow-changing **cell endpoint map** (cell → provider / bucket /
+endpoint) — the DNS-of-cells: dozens of entries, cacheable, not a
+per-fetch single point of failure.
+
+### Replication, DR, and the location descriptor
+
+When a result is replicated across providers / regions for DR, the
+logical URI is unchanged; the §8 **location descriptor** carries N
+`locations[]` (`s3` / `gcs` / `azure` / Ceph RGW / SeaweedFS) each with a
+`replica_state` (`primary` / `async-replica`), and
+
+```
+resolve(noetl_uri, requester, purpose, preferred_region, required_capability)
+  → access plan
+```
+
+returns the nearest healthy replica. Failover renames nothing. Honoring
+the §4 cell principles, cell-to-cell exchange carries these references
+and manifests — never raw cross-cell database writes — the same boundary
+the materialiser pool already respects.
+
+What the model buys: **idempotent overwrite** (a fixed version rewrites
+the same key), **trivial GC** (per-shard / per-execution prefix delete),
+**deterministic replay** (the name is computed from the envelope + shard
+function, never carried), and **locality-aware routing** (the shard
+resolves the home cell so a consumer prefers the nearest replica).
 
 ## Result tiers
 
@@ -163,12 +214,12 @@ The size threshold that already gates inline-vs-reference
 (`NOETL_EVENT_RESULT_CONTEXT_MAX_BYTES`) selects the tier:
 
 1. **Small result** → stays inline in the event. No object-store write.
-2. **Over-budget tabular result** → Arrow Feather under the derived URN.
+2. **Over-budget tabular result** → Arrow Feather at the logical URI's resolved location.
    Feather is the on-disk/object-store form of the Arrow IPC stream the
    worker already encodes for the shared-memory cache; it is mmap-able and
    reads zero-copy from `pyarrow` and the Rust `arrow` crate.
 3. **Over-budget non-tabular result** (shell stdout, opaque HTTP JSON)
-   → JSON (or Parquet) under the derived URN. Feather is for rowsets;
+   → JSON (or Parquet) at the same resolved location. Feather is for rowsets;
    the rest needs a fallback encoding.
 
 In **all** tiers the event carries a small **predicate `extracted`
@@ -187,11 +238,12 @@ by derivation.
    offset its executions were durably acked at.
 2. It replays the local-only tail: pure condition evaluations re-derive
    for free; non-side-effecting tools re-run; side-effecting tools are
-   **skipped if their completion is already durable** (URN exists / cycle
-   acked), otherwise dispatched.
+   **skipped if their completion is already durable** (the logical URI's
+   object already exists / the cycle is acked), otherwise dispatched.
 3. The projector and materialiser are at-least-once consumers and must be
-   idempotent — dedup on `event_id`, overwrite on the derived URN. Both
-   properties are already required by the CQRS projector.
+   idempotent — dedup on `event_id`, overwrite at the logical URI's
+   resolved location. Both properties are already required by the CQRS
+   projector.
 
 ## What already exists vs what is new
 
@@ -208,7 +260,8 @@ by derivation.
 
 **New in this model (the three pieces):**
 
-1. **Derivable URN addressing** — drop the carried reference; derive the
+1. **Logical-URI addressing** — the stable `noetl://<tenant>/<project>/...`
+   Resource Locator; drop the carried opaque reference and derive the
    location from identity.
 2. **Local-first dual write** — the worker's local buffer is the fast
    path; the JetStream publish is the durability channel (extends the
@@ -231,7 +284,7 @@ umbrella they both serve.
 
 ## Open questions (red-team targets)
 
-- **Attempt semantics in the URN** — overwrite-on-retry (omit/fix
+- **Attempt/version semantics in the logical URI** — overwrite-on-retry (omit/fix
   `attempt`) vs keep-every-attempt. Overwrite is simpler and GC-friendly;
   keep-every is better for forensic replay. Likely: overwrite by default,
   keep-every behind a debug flag.

--- a/docs/architecture/event_wal_and_derivable_storage.md
+++ b/docs/architecture/event_wal_and_derivable_storage.md
@@ -1,0 +1,260 @@
+---
+id: event_wal_and_derivable_storage
+title: Event WAL and Derivable Result Storage
+sidebar_label: Event WAL + Derivable Storage
+sidebar_position: 9
+---
+
+# Event WAL and Derivable Result Storage
+
+How NoETL makes the event and result path fast **and** crash-resilient
+at the same time: treat NATS JetStream as the write-ahead log, run
+local memory as a read cache ahead of the last durable offset, derive
+result locations from a naming convention instead of carrying
+references, and let independent pools project the log and materialise
+results to an Arrow Feather tier in object store.
+
+This is the runtime-storage evolution of
+[Sink-Driven Data Storage](./sink_driven_storage.md) (the Python-era
+result-reference pattern) and a direct consequence of the
+[Ephemeral Blueprints](./ephemeral_blueprints.md) compute-data boundary.
+It folds together two in-flight efforts — the CQRS event-log split
+([noetl/ai-meta#103](https://github.com/noetl/ai-meta/issues/103)) and
+results-by-reference / references-in-state
+([noetl/ai-meta#101](https://github.com/noetl/ai-meta/issues/101)) —
+into one model rather than running them as parallel tracks.
+
+## One-paragraph statement
+
+Every atomic cycle of an execution — a tool result **or** a condition
+evaluation — appends an event to a local in-process buffer that the
+running orchestrator and worker read from immediately, and publishes the
+same event to a NATS JetStream stream in parallel. The JetStream
+publish-ack is the durability boundary: the stream is the write-ahead
+log. Two independent consumer pools drain that log — a **projector**
+that rebuilds the read model (`projection_snapshot`) and a
+**materialiser** that writes over-budget result payloads as Arrow
+Feather files to object store. Result locations are **derived from a
+naming convention** (a URN computed from the execution identity), so
+state carries predicate fields and derivable coordinates, never a
+payload and never an opaque reference string. A crashed instance resumes
+from the last log offset its work was durably acked at and replays only
+the local-only tail.
+
+## Why
+
+Three problems, one model.
+
+1. **The synchronous event write is the scaling bottleneck.** Today an
+   atomic cycle blocks on a `noetl.event` `INSERT` before it can ack.
+   Under fan-out (cursor mode, 10×1000 PFT) that serialises the hot path
+   against the database connection pool — exactly the ceiling described
+   in the scale-constraints analysis. Moving durability to a JetStream
+   publish-ack takes the database off the hot path.
+
+2. **Carried payloads and references bloat state.** Storing full results
+   in the event (or, later, carrying an opaque `reference.ref` string and
+   re-hydrating it inline so the orchestrator can evaluate guards) pushes
+   megabytes back through command context and snapshots. The
+   [Ephemeral Blueprints](./ephemeral_blueprints.md) rule is explicit:
+   context carries references, not data. A **derivable** location carries
+   even less — the coordinates that address it are already in the event
+   envelope.
+
+3. **Resilience needs an independent checkpoint.** If the only durable
+   record is written synchronously by the same process doing the work, a
+   crash mid-cycle loses the tail. An independently-consumed log lets a
+   restart resume from a checkpoint it did not have to write itself.
+
+## The model
+
+```
+          atomic cycle (tool result | condition eval)
+                          │
+            ┌─────────────┴──────────────┐
+            ▼                             ▼
+   local in-process buffer        NATS JetStream  ──  the WAL
+   (memory / temp file)           publish-ack = durable
+   read cache, ahead of                  │
+   last acked offset             ┌───────┴────────┐
+            │                    ▼                ▼
+   orchestrator / worker    projector pool   materialiser pool
+   read the fast path       → projection_     → Arrow Feather in
+                              snapshot           object store, keyed
+                              (read model)       by derived URN
+```
+
+- **Local buffer = read cache.** It accelerates a process reading its
+  *own* recent appends. It is not a shared cache: another process never
+  reads this process's memory or temp files. Cross-process reads always
+  go through the log and the object-store tier (or the colocated shared-
+  memory cache for same-node acceleration, which already exists with
+  lease expiry).
+- **NATS JetStream = WAL.** A publish that waits for the stream ack is
+  durable and replicated. Resume-from-offset is well-defined: anything
+  past the last ack is replayed.
+- **Projector pool** drains the log into `projection_snapshot` (the read
+  model the orchestrator reads). This already exists.
+- **Materialiser pool** drains the same log, and for over-budget results
+  writes Arrow Feather to object store under the derived URN. The shadow
+  materialiser consumer already exists; this extends it to write the
+  durable Feather tier.
+
+## The load-bearing decision: where the durability barrier sits
+
+Local-ahead-of-durable is only crash-safe if the replay window respects
+non-idempotent work. The two atomic kinds need **different** treatment:
+
+| Atomic kind | Replay safety | Treatment |
+| :-- | :-- | :-- |
+| **Condition evaluation** | Pure — re-derives from state for free | Local + asynchronous publish. Never blocks. |
+| **Tool execution, no side effect** | Re-runnable | Local + asynchronous publish. |
+| **Tool execution with side effects** (charges a card, sends a message, writes an external system) | **Not** replay-safe | Durable boundary: the result's publish-ack is the commit point, and a resume must not re-dispatch a tool whose completion is already durable. |
+
+The rule: **the durability barrier sits at side-effecting tool
+boundaries, nowhere else.** Blocking every cycle is just the synchronous
+write we are escaping; blocking nowhere re-charges cards on crash.
+Concretely, before a resumed execution re-dispatches a side-effecting
+tool for `(execution_id, step, frame, attempt)`, it checks whether that
+cycle's completion is already in the log (equivalently: whether the
+derived result URN already exists). If it does, the cycle is skipped and
+the recorded result adopted. This is the same shape as the
+callback/hook rule — time in the external system is free; the worker
+slot is only held while a block actually runs.
+
+## Derivable URN grammar
+
+The location is a pure function of execution identity. It must encode
+everything that distinguishes one result from another, or fan-out and
+retries collide on the same key:
+
+```
+urn:noetl:result:<execution_id>:<step>:<frame_or_claim_index>:<attempt>
+```
+
+- `execution_id` and `step` are already in the event envelope.
+- `frame_or_claim_index` is **mandatory** for fan-out. Cursor mode
+  produces many results per step; without the index, row 0 and row 5
+  write the same object and corrupt each other.
+- `attempt` disambiguates retries when you want both kept; omit it (or
+  fix it at the latest) when you want retries to **overwrite**.
+
+The object-store key is a deterministic encoding of the URN, e.g.
+
+```
+noetl/<execution_id>/<step>/<frame>/<attempt>.feather
+```
+
+What the convention buys:
+
+- **Idempotent overwrite.** A retry that fixes `attempt` rewrites the
+  same key — no orphaned objects, single atomic PUT, clean reads.
+- **Trivial garbage collection.** TTL or end-of-execution cleanup is a
+  prefix delete (`noetl/<execution_id>/`).
+- **Deterministic replay.** The projector and any consumer **compute**
+  the URN from the envelope; the event never carries it. State shrinks to
+  the coordinates already present plus the predicate block below.
+- **Prefix discovery.** "All results for execution X" is a prefix list,
+  not a reference set to thread through state.
+
+## Result tiers
+
+The size threshold that already gates inline-vs-reference
+(`NOETL_EVENT_RESULT_CONTEXT_MAX_BYTES`) selects the tier:
+
+1. **Small result** → stays inline in the event. No object-store write.
+2. **Over-budget tabular result** → Arrow Feather under the derived URN.
+   Feather is the on-disk/object-store form of the Arrow IPC stream the
+   worker already encodes for the shared-memory cache; it is mmap-able and
+   reads zero-copy from `pyarrow` and the Rust `arrow` crate.
+3. **Over-budget non-tabular result** (shell stdout, opaque HTTP JSON)
+   → JSON (or Parquet) under the derived URN. Feather is for rowsets;
+   the rest needs a fallback encoding.
+
+In **all** tiers the event carries a small **predicate `extracted`
+block** inline — the navigable, bounded summary the orchestrator reads
+to evaluate `when:` / `set:` / cursor fan-out **without** a fetch. This
+is the structural-summary mechanism already built for references-in-
+state (objects keep their keys, arrays keep their first element so
+`rows[0].<field>` resolves, large strings collapse to a length marker,
+the whole block is byte-bounded). It survives this model unchanged — the
+only thing that goes away is the opaque `reference.ref` string, replaced
+by derivation.
+
+## Crash recovery semantics
+
+1. A restarted instance reads the read model and the log up to the last
+   offset its executions were durably acked at.
+2. It replays the local-only tail: pure condition evaluations re-derive
+   for free; non-side-effecting tools re-run; side-effecting tools are
+   **skipped if their completion is already durable** (URN exists / cycle
+   acked), otherwise dispatched.
+3. The projector and materialiser are at-least-once consumers and must be
+   idempotent — dedup on `event_id`, overwrite on the derived URN. Both
+   properties are already required by the CQRS projector.
+
+## What already exists vs what is new
+
+**Already scaffolded (CQRS + results-by-reference work):**
+
+- `noetl_events` JetStream stream, the **projector** consumer →
+  `projection_snapshot`, and a shadow **materialiser** consumer — the
+  "separate process reads NATS and writes elsewhere" pools.
+- The Arrow IPC encoder and the colocated shared-memory cache with lease
+  expiry — columnar staging and same-node fast reads.
+- The durable result store and the inline-vs-reference size threshold.
+- The bounded, navigable predicate `extracted` block.
+- Application-side snowflake IDs (so identity exists before the write).
+
+**New in this model (the three pieces):**
+
+1. **Derivable URN addressing** — drop the carried reference; derive the
+   location from identity.
+2. **Local-first dual write** — the worker's local buffer is the fast
+   path; the JetStream publish is the durability channel (extends the
+   2d-3 worker-publish direction).
+3. **Arrow Feather durable tier** under the materialiser, keyed by URN.
+
+## How it folds into the open work
+
+- **[noetl/ai-meta#103](https://github.com/noetl/ai-meta/issues/103)
+  (CQRS event-log split)** provides the stream, the projector, and the
+  materialiser. The 2d-3 step (worker publishes its native event shape to
+  the stream) becomes the local-first dual write here.
+- **[noetl/ai-meta#101](https://github.com/noetl/ai-meta/issues/101)
+  (references-in-state)** provides the predicate `extracted` block, which
+  stays. Its carried `reference.ref` string is superseded by derivation.
+
+The two stop being separate tracks: one is the log + projection, the
+other is the result tier addressed off the same log. This document is the
+umbrella they both serve.
+
+## Open questions (red-team targets)
+
+- **Attempt semantics in the URN** — overwrite-on-retry (omit/fix
+  `attempt`) vs keep-every-attempt. Overwrite is simpler and GC-friendly;
+  keep-every is better for forensic replay. Likely: overwrite by default,
+  keep-every behind a debug flag.
+- **Local tail bound** — how far local may run ahead of the last ack
+  before back-pressure. Too far widens the replay window and the
+  idempotency burden; too tight approaches the synchronous write.
+- **Non-tabular fallback format** — JSON vs Parquet for the over-budget
+  non-tabular tier.
+- **Side-effect classification** — how a tool declares itself
+  side-effecting so the barrier knows where to block. A tool-registry
+  attribute is the natural home.
+
+## Relationship to the boundary rules
+
+This model honors — and sharpens — the platform's boundary rules:
+
+- **[Ephemeral Blueprints](./ephemeral_blueprints.md)** — context carries
+  references, not data; derivation carries even less.
+- **NoETL-owned data via the server API only** — workers publish to the
+  stream and read the object-store tier; they do not reach `noetl.*`
+  tables directly. The materialiser and projector pools are system-pool
+  consumers that call the server's internal API for anything touching
+  NoETL-owned tables.
+- **Observability** — every new boundary (publish, materialise, resolve
+  by URN) ships its span, metric, and `execution_id` correlation in the
+  same change set.

--- a/docs/architecture/system_pool_and_wasm_plugins.md
+++ b/docs/architecture/system_pool_and_wasm_plugins.md
@@ -398,6 +398,62 @@ closest fit.
   tower); the plug-in surface should be the route handlers'
   **bodies** for customisable routes, not the routing itself.
 
+### Compile target and the capability boundary
+
+Real plug-ins compile to **`wasm32-wasip1` / `wasm32-wasip2`** (not bare
+`wasm32-unknown-unknown`) so Rust `std` and the Apache Arrow crates —
+which support these targets — build inside the module.
+
+But targeting WASI does **not** mean granting WASI's file / network /
+env APIs. That would let a plug-in open its own socket to GCS or write a
+file directly, bypassing the server boundary and violating
+[the data-access boundary](https://github.com/noetl/noetl/blob/main/agents/rules/data-access-boundary.md).
+Instead:
+
+- The granted surface is **NoETL host functions registered on the
+  `wasmtime` `Linker`** — `noetl.event_publish`, `noetl.result_put`,
+  `noetl.object_put`, etc. The host implements the actual write, so
+  placement, scrub, audit, and RBAC stay enforced. An import the host did
+  not register fails `instantiate`, so the capability ring is structural.
+- **WASI is limited to the pure subset** (clock, random) or stubbed.
+  No `fd_*` filesystem, no `sock_*` networking. A plug-in reaches the
+  outside world only through NoETL capabilities.
+
+### Data plane — Arrow across the boundary, no serialization
+
+The cost WASM adds is copying complex data across the boundary. For a
+data runtime that is the whole game, so plug-ins move **Apache Arrow IPC
+/ Feather buffers** through linear memory rather than JSON:
+
+1. the module exports an allocator (`alloc(size) -> ptr`);
+2. the host calls it for an isolated block (never writes to an arbitrary
+   offset), copies the Arrow buffer straight into the module's linear
+   memory, and invokes `run(ptr, len) -> packed(out_ptr << 32 | out_len)`;
+3. the plug-in reads the Arrow buffers **in place** via pointers +
+   lengths — no encode / decode — and writes its output buffer back.
+
+The buffer is the same Arrow bytes the worker already produces for
+over-budget results (`noetl_tools::arrow_codec`), so a result transits
+worker → object store → plug-in without ever re-serializing. The
+worker host (`noetl-worker` `plugin` module) implements this as
+`WasmPluginHost::invoke_bytes`; a round-trip test pushes a real Arrow IPC
+buffer through and asserts it returns byte-identical.
+
+For plug-ins that talk **across the network** (cell-to-cell, region-to-
+region — see the
+[Event WAL + Derivable Storage](./event_wal_and_derivable_storage.md)
+topology model) rather than in-process, the equivalent is **Arrow
+Flight**: stream RecordBatch chunks into the plug-in endpoint instead of
+the shared-memory hand-off.
+
+### Distribution
+
+Compiled modules live in the **catalog** (the managed, replaceable plug-in
+library) keyed by `(path, version, digest)`. They can also be distributed
+as **OCI artifacts** and executed container-native via a `runwasi`-style
+shim — a sub-megabyte module with sub-millisecond start, versus tens of
+megabytes and a full OS boot for a Linux container.
+
 ## The packaging shape (revised v2)
 
 There's **no new compiled binary** for publisher / projector /

--- a/docs/architecture/system_pool_and_wasm_plugins.md
+++ b/docs/architecture/system_pool_and_wasm_plugins.md
@@ -519,6 +519,80 @@ Cons: requires building the YAML-to-WASM compiler.
 (faster to ship, validates the runtime + capability + reload
 pipeline).  Migrate to Option 2 once the compiler is built.
 
+## WASM dispatch convention
+
+The runtime built for Option 1 is shipped and validated end to end (the
+plug-in module registry, the wasmtime host + capability ring, the HTTP
+`PluginSource`, the reference plug-in, and the dispatcher's
+load → run → collect → flush loop — noetl/ai-meta#105 Rounds 1-5).  What
+remains to make it *live* is the **dispatch convention**: how a playbook
+declares WASM execution, and how the command routes to the host instead
+of the tool registry.
+
+### How a playbook opts in (author-facing)
+
+A catalog playbook — in the Option-1 phase, typically a `system/`
+playbook — opts into compiled execution with an `executor` block:
+
+```yaml
+executor:
+  runtime: wasm                 # vs the default interpreted runtime
+  plugin:
+    path: system/materialiser   # catalog path of the compiled module
+    version: 3                  # catalog version
+    # digest is NOT authored — the registry is the digest authority
+  capabilities:                 # the granted ring (a subset of the host's)
+    - object_put
+    - result_put
+    - event_publish
+```
+
+- The author never writes a digest.  The plug-in module registry
+  (`noetl.plugin_module`, served by `GET /api/internal/plugins/{path}`)
+  is the digest authority; the worker pins the digest it fetched into its
+  cache key.
+- `capabilities` narrows the host's full ring per plug-in
+  (defense-in-depth): a plug-in is granted only the host functions it
+  declares.  Omitting the list grants nothing (deny-by-default, matching
+  `NullCapabilities`).
+
+### Wire shape and routing
+
+- The orchestrator / system-pool runner, dispatching a step flagged
+  `runtime: wasm`, emits a command with **`tool_kind: "wasm"`** and an
+  `input` carrying the step's payload plus the plug-in reference
+  (`{path, version}`) and the granted capability list.  `tool_kind` is the
+  worker's dispatch discriminator, so routing needs no new command field —
+  the author-facing `executor.runtime: wasm` lowers to a `tool_kind:
+  "wasm"` command.
+- The worker dispatch, on `tool_kind == "wasm"`, resolves the digest from
+  the registry, builds the `PluginKey{path, version, digest}`, and calls
+  `WasmDispatcher::run_and_apply(key, input, client, execution_id, step)`
+  — load (catalog fetch + hot-reload on a version bump) → invoke over the
+  data-plane ABI → collect `CapIntent`s → flush to the control plane.  The
+  capability ring is scoped to the declared `capabilities`.
+- **Input** to the plug-in is the command's payload bytes (for the
+  materialiser, a batch of events / the trigger payload); its **output**
+  plus the flushed intents are the step result.
+
+### Error surfacing (resolves Open question 2)
+
+A WASM module panic is a `wasmtime::Trap`, which the host already turns
+into a `PluginError::Invoke` rather than crashing the worker.  The
+dispatcher surfaces it as a contained `call.error` structured event for
+that step — the system-pool worker keeps running and the failure is
+visible in the event log, exactly like a tool error.
+
+### The one open design choice
+
+`tool_kind: "wasm"` (a tool kind) vs an `executor` field on the command
+envelope.  **Recommendation: `tool_kind: "wasm"`** — it reuses the
+existing dispatch discriminator with zero new command/envelope fields,
+and the author-facing surface stays the richer `executor` block that
+lowers to it.  The alternative (a first-class `command.executor` field)
+is cleaner conceptually but ripples through the command schema across
+server + worker + the executor crate for no near-term benefit.
+
 ## Open questions
 
 1. **What is the minimum compiled core?** The current cut is

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -26,6 +26,7 @@ const sidebars: SidebarsConfig = {
         'getting-started/design-philosophy',
         'getting-started/semantic-pipeline',
         'architecture/sink_driven_storage',
+        'architecture/event_wal_and_derivable_storage',
         'architecture/mcp_catalog_architecture',
         'architecture/agent_orchestration',
         'architecture/playbook_as_mcp_server',


### PR DESCRIPTION
Records the design refinements for the plug-in compilation capability (noetl/ai-meta#105), per the standing direction on WASI + Arrow zero-copy:

- **Compile target** `wasm32-wasip1/p2` (Rust std + Arrow crates compile), but the granted surface is **NoETL host functions via the `Linker`, not raw WASI fs/net** — preserving the data-access boundary (audit/scrub/placement). WASI limited to the pure subset.
- **Data plane**: Arrow IPC/Feather buffers across the boundary via the `alloc(size)->ptr` linear-memory pattern, no JSON serialization. Implemented as the worker's `WasmPluginHost::invoke_bytes` ([noetl/worker#93](https://github.com/noetl/worker/pull/93)), proven with a real Arrow IPC round-trip. **Arrow Flight** for cross-network (cell/region) plug-ins.
- **Distribution**: catalog (the managed library) keyed by `(path, version, digest)`; OCI artifacts + `runwasi` shim as the container-native option.

Refs noetl/ai-meta#105

🤖 Generated with [Claude Code](https://claude.com/claude-code)