### PR TITLE
docs: noetl exec -> noetl run across tutorials, examples and architecture

### DIFF
--- a/docs/ai-meta/agent-orchestration.md
+++ b/docs/ai-meta/agent-orchestration.md
@@ -80,7 +80,7 @@ NoETL's server already handles capabilities 1 through 4 for playbooks. NATS prov
 
 **Discovery:** The server tracks versioned resources through `noetl.catalog.kind` and `noetl.resource.name`. Resource kinds include `playbook`, `agent`, `mcp`, `memory`, and `credential`, with capability filters for agent discovery.
 
-**Invocation:** `noetl exec <playbook> --set key=value` already starts a playbook with input parameters. An agent invocation is the same call, with `resource_kind: "agent"` when the catalog entry is registered as an agent.
+**Invocation:** `noetl run <playbook> --set key=value` already starts a playbook with input parameters. An agent invocation is the same call, with `resource_kind: "agent"` when the catalog entry is registered as an agent.
 
 **State tracking:** `noetl status` shows running, completed, and failed executions. Agent status is playbook execution status.
 
@@ -337,7 +337,7 @@ To experiment with the agent-as-playbook pattern today:
 
 1. **Write an agent playbook** with `tool.kind: agent` and `framework: adk|langchain|custom`
 2. **Deploy it** to your NoETL server like any other playbook
-3. **Invoke it** with `noetl exec <agent-playbook> --set goal="..."`
+3. **Invoke it** with `noetl run <agent-playbook> --set goal="..."`
 4. **Orchestrate multiple agents** by writing a parent playbook that calls agent playbooks as nested steps
 5. **Track results** with `noetl status` and persist decisions to `ai-meta/memory/`
 

--- a/docs/architecture/agent_failure_diagnostics.md
+++ b/docs/architecture/agent_failure_diagnostics.md
@@ -186,7 +186,7 @@ networks.
 Run it from `ai-meta`:
 
 ```bash
-EXEC_ID=$(noetl exec tests/spike/spike_e2e_test \
+EXEC_ID=$(noetl run tests/spike/spike_e2e_test \
   --runtime distributed \
   --payload '{"escalate_to":"none"}' \
   --json | jq -r '.execution_id')

--- a/docs/architecture/agent_orchestration.md
+++ b/docs/architecture/agent_orchestration.md
@@ -207,7 +207,7 @@ exercises an auto-troubleshoot-enabled failing agent, then pass the
 execution id to the smoke:
 
 ```bash
-EXEC_ID=$(noetl exec tests/spike/spike_e2e_test \
+EXEC_ID=$(noetl run tests/spike/spike_e2e_test \
   --runtime distributed \
   --payload '{"escalate_to":"none"}' \
   --json | jq -r '.execution_id')

--- a/docs/architecture/triage_model_selection.md
+++ b/docs/architecture/triage_model_selection.md
@@ -92,7 +92,7 @@ investigation.
 Workloads opt in by passing `ollama_model: "gemma4:e4b"`:
 
 ```bash
-noetl exec tests/spike/spike_e2e_test \
+noetl run tests/spike/spike_e2e_test \
   --runtime distributed \
   --payload '{"escalate_to":"none","ollama_model":"gemma4:e4b"}'
 ```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -50,12 +50,12 @@ execution workload sent to the server. Both forms below set the same workload
 fields:
 
 ```bash
-noetl exec catalog://fixtures/playbooks/pft_flow_test/test_pft_flow_v2@8 \
+noetl run catalog://fixtures/playbooks/pft_flow_test/test_pft_flow_v2@8 \
   --runtime distributed \
   --set num_facilities=1 \
   --set patients_per_facility=10
 
-noetl exec catalog://fixtures/playbooks/pft_flow_test/test_pft_flow_v2@8 \
+noetl run catalog://fixtures/playbooks/pft_flow_test/test_pft_flow_v2@8 \
   --runtime distributed \
   --set workload.num_facilities=1 \
   --set workload.patients_per_facility=10

--- a/docs/examples/integrations/quantum_networking_runner.md
+++ b/docs/examples/integrations/quantum_networking_runner.md
@@ -22,7 +22,7 @@ Default mode is `nvidia_simulator`.
 Run:
 
 ```bash
-noetl exec tests/fixtures/playbooks/api_integration/quantum_networking/quantum_networking_runner.yaml -r local \
+noetl run tests/fixtures/playbooks/api_integration/quantum_networking/quantum_networking_runner.yaml -r local \
   --set provider=nvidia_simulator \
   --set shots=1024
 ```
@@ -31,7 +31,7 @@ Optional GPU request:
 
 ```bash
 export NVIDIA_USE_GPU=true
-noetl exec tests/fixtures/playbooks/api_integration/quantum_networking/quantum_networking_runner.yaml -r local \
+noetl run tests/fixtures/playbooks/api_integration/quantum_networking/quantum_networking_runner.yaml -r local \
   --set provider=nvidia_simulator \
   --set shots=4096
 ```
@@ -60,7 +60,7 @@ export IBM_QUANTUM_API_VERSION="2024-06-13"
 Run:
 
 ```bash
-noetl exec tests/fixtures/playbooks/api_integration/quantum_networking/quantum_networking_runner.yaml -r local \
+noetl run tests/fixtures/playbooks/api_integration/quantum_networking/quantum_networking_runner.yaml -r local \
   --set provider=ibm_api
 ```
 

--- a/docs/operations/bump_image.md
+++ b/docs/operations/bump_image.md
@@ -89,7 +89,7 @@ rollout. This is useful for validation loops:
 Deploy a released NoETL tag to all default runtime components:
 
 ```bash
-noetl exec noetl/lifecycle/bump_image \
+noetl run noetl/lifecycle/bump_image \
   --runtime distributed \
   --payload '{
     "namespace": "noetl",
@@ -109,7 +109,7 @@ Target one component explicitly when only a single deployment needs to
 move:
 
 ```bash
-noetl exec noetl/lifecycle/bump_image \
+noetl run noetl/lifecycle/bump_image \
   --runtime distributed \
   --payload '{
     "deployment": "noetl-worker",

--- a/docs/operations/notes.md
+++ b/docs/operations/notes.md
@@ -156,7 +156,7 @@ done
 ## 7) Execute stress test
 
 ```bash
-noetl exec catalog://tests/fixtures/playbooks/batch_execution/server_oom_stress_test_v2 \
+noetl run catalog://tests/fixtures/playbooks/batch_execution/server_oom_stress_test_v2 \
   --runtime distributed \
   --payload '{"total_items":3000,"batch_size":50,"concurrent_batches":1,"items_max_in_flight":1}' \
   --json

--- a/docs/reference/rust_local_execution.md
+++ b/docs/reference/rust_local_execution.md
@@ -8,16 +8,16 @@ Local mode is intended for development, testing, and CI/CD. Conceptually, the co
 
 ```bash
 # Execute a playbook in local mode
-noetl exec ./playbook.yaml -r local
+noetl run ./playbook.yaml -r local
 
 # With workload overrides
-noetl exec ./playbook.yaml -r local --set key=value
+noetl run ./playbook.yaml -r local --set key=value
 
 # Target a specific step label (runtime-defined)
-noetl exec ./playbook.yaml -r local --target my_step
+noetl run ./playbook.yaml -r local --target my_step
 
 # Dry-run (validate only)
-noetl exec ./playbook.yaml -r local --dry-run
+noetl run ./playbook.yaml -r local --dry-run
 ```
 
 ## current DSL semantics (what local mode must preserve)

--- a/docs/tutorials/01-quickstart.md
+++ b/docs/tutorials/01-quickstart.md
@@ -80,7 +80,7 @@ playbook from `repos/ops`:
 
 ```bash
 # From the ai-meta workspace root.
-noetl exec automation/development/noetl --runtime local --payload '{
+noetl run automation/development/noetl --runtime local --payload '{
   "namespace": "noetl",
   "noetl_image": "ghcr.io/noetl/noetl:v2.37.2",
   "gateway_image": "ghcr.io/noetl/gateway:v2.10.0",
@@ -115,8 +115,8 @@ triage model. See [Triage Model Selection](../architecture/triage_model_selectio
 for the rationale and tier comparison.
 
 ```bash
-kubectl -n noetl exec deploy/ollama -- ollama pull gemma3:4b
-kubectl -n noetl exec deploy/ollama -- ollama list
+kubectl -n noetl run deploy/ollama -- ollama pull gemma3:4b
+kubectl -n noetl run deploy/ollama -- ollama list
 ```
 
 `ollama list` should show `gemma3:4b` at roughly 3.0 GB.
@@ -129,7 +129,7 @@ deliberately invokes a failing sub-playbook so the auto-troubleshoot path
 exercises end-to-end:
 
 ```bash
-EXEC_ID=$(noetl exec tests/spike/spike_e2e_test \
+EXEC_ID=$(noetl run tests/spike/spike_e2e_test \
   --runtime distributed \
   --payload '{"escalate_to":"none"}' \
   --json | jq -r '.execution_id')

--- a/docs/tutorials/02-gke-production-deploy.md
+++ b/docs/tutorials/02-gke-production-deploy.md
@@ -48,7 +48,7 @@ It supports `provision`, `deploy`, `provision-deploy`, `status`, and
 plus full stack deploy in one shot:
 
 ```bash
-noetl exec automation/gcp_gke/noetl-gke-fresh-stack \
+noetl run automation/gcp_gke/noetl-gke-fresh-stack \
   --runtime local \
   --payload '{
     "action": "provision-deploy",
@@ -127,7 +127,7 @@ kubectl -n ${K8S_SA_NAMESPACE} annotate serviceaccount ${K8S_SA_NAME} \
 Confirm a worker pod can fetch a token from the metadata server:
 
 ```bash
-kubectl -n noetl exec deploy/noetl-worker -- \
+kubectl -n noetl run deploy/noetl-worker -- \
   curl -s -H "Metadata-Flavor: Google" \
   "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
   | jq -r '.token_type'
@@ -182,7 +182,7 @@ for verification.
 
 ```bash
 # Bump noetl-server
-noetl exec noetl/lifecycle/bump_image \
+noetl run noetl/lifecycle/bump_image \
   --runtime distributed \
   --payload '{
     "deployment": "noetl-server",
@@ -191,7 +191,7 @@ noetl exec noetl/lifecycle/bump_image \
   }'
 
 # Bump noetl-worker
-noetl exec noetl/lifecycle/bump_image \
+noetl run noetl/lifecycle/bump_image \
   --runtime distributed \
   --payload '{
     "deployment": "noetl-worker",

--- a/docs/tutorials/03-self-troubleshooting-playbook.md
+++ b/docs/tutorials/03-self-troubleshooting-playbook.md
@@ -187,7 +187,7 @@ noetl catalog list | grep tutorials
 ## Step 4 — Invoke the parent
 
 ```bash
-EXEC_ID=$(noetl exec tutorials/canary_with_diagnosis \
+EXEC_ID=$(noetl run tutorials/canary_with_diagnosis \
   --runtime distributed \
   --payload '{}' \
   --json | jq -r '.execution_id')

--- a/docs/tutorials/05-add-new-mcp-backend.md
+++ b/docs/tutorials/05-add-new-mcp-backend.md
@@ -232,7 +232,7 @@ Validate the stub responds to the same `triage_mcp_server` workload
 override that `mcp/vertex-ai-stub` does:
 
 ```bash
-EXEC_ID=$(noetl exec tests/spike/spike_e2e_test \
+EXEC_ID=$(noetl run tests/spike/spike_e2e_test \
   --runtime distributed \
   --payload '{
     "escalate_to": "none",
@@ -499,7 +499,7 @@ python3 scripts/live_vs_persisted_parity_smoke.py     # 5/5 with Bedrock fixture
 python3 scripts/worker_workload_forwarding_smoke.py
 
 # Real Bedrock spike
-EXEC_ID=$(noetl exec tests/spike/spike_e2e_test \
+EXEC_ID=$(noetl run tests/spike/spike_e2e_test \
   --runtime distributed \
   --payload '{
     "escalate_to": "none",

--- a/docs/tutorials/06-widget-rendering.md
+++ b/docs/tutorials/06-widget-rendering.md
@@ -106,7 +106,7 @@ noetl register widget_render_tutorial.yaml
 Then run it:
 
 ```bash
-EXEC_ID=$(noetl exec tutorials/widget_render_tutorial \
+EXEC_ID=$(noetl run tutorials/widget_render_tutorial \
   --runtime distributed \
   --json | jq -r '.execution_id')
 


### PR DESCRIPTION
noetl-cli 4.19.0 made `run` the playbook verb; `exec` is a deprecated working alias that prints a stderr nudge. Docs are where a newcomer copies from, so they should not teach the deprecated spelling (noetl/ai-meta#193).

**29 run-verb occurrences across 14 files.** Non-breaking — the alias still works.

Narrow by construction (`noetl` + whitespace + `exec` followed by whitespace or end-of-line), so the 2 `noetl execute` uses — the separate `execute <playbook|status|rerun>` group — are untouched.

Refs noetl/ai-meta#193